### PR TITLE
feat(renovate): shared preset — 1 day release age, merge confidence auto-merge, FerrLabs packages fast-track

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "mergeConfidence:all-badges",
+    ":semanticCommits",
+    ":dependencyDashboard"
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "minimumReleaseAge": "1 day",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 4,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "FerrLabs own packages — trust them, merge without delay",
+      "matchPackagePatterns": ["^@ferrlabs/"],
+      "minimumReleaseAge": "0",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrLabs packages"
+    },
+    {
+      "description": "High merge confidence — auto-merge non-major",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchMergeConfidence": ["high", "very high"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Cargo patch + minor — auto-merge (no merge confidence data on crates.io)",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "GitHub Actions — grouped + auto-merge",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Dockerfile base images — grouped + auto-merge",
+      "matchManagers": ["dockerfile"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "Docker images"
+    },
+    {
+      "description": "Major updates — always manual",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds the org default Renovate preset at `default.json` (Renovate's convention for `FerrLabs/.github`).

Every repo's `renovate.json` will be updated to `extends: ["local>FerrLabs/.github"]` in follow-up PRs.

Rules:
- Global `minimumReleaseAge: 1 day` — protects against typosquatting and unpublished releases.
- Mend Renovate merge confidence badges — auto-merge non-major updates when confidence is high or very high.
- `@ferrlabs/*` packages fast-track: no release-age delay, auto-merge.
- Cargo patch/minor auto-merge (crates.io has no confidence data).
- GitHub Actions and Dockerfile updates grouped and auto-merged.
- Major updates always manual.