### PR TITLE
chore(renovate): disable vulnerability alerts, defer to dependabot

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,10 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 4,
   "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "osvVulnerabilityAlerts": false,
   "packageRules": [
     {
       "description": "FerrLabs own packages — trust them, merge without delay",


### PR DESCRIPTION
Renovate and Dependabot were both raising security PRs for the same CVEs. Dependabot's `security updates` is enabled per-repo (github native, instant); Renovate's `vulnerabilityAlerts` duplicated the work.

Split of responsibilities:
- **Dependabot** → security updates only (CVE fixes, GitHub Security Advisories)
- **Renovate** → everything else (regular version bumps, cargo/GH Actions/Docker/npm)

Disable `vulnerabilityAlerts` + `osvVulnerabilityAlerts` on the Renovate side.