### PR TITLE
feat(renovate): take over security updates from dependabot

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,9 +12,15 @@
   "prHourlyLimit": 4,
   "labels": ["dependencies"],
   "vulnerabilityAlerts": {
-    "enabled": false
+    "enabled": true,
+    "labels": ["security"],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "squash",
+    "minimumReleaseAge": "0",
+    "prPriority": 10
   },
-  "osvVulnerabilityAlerts": false,
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "description": "FerrLabs own packages — trust them, merge without delay",


### PR DESCRIPTION
## Summary
- Enable Renovate `vulnerabilityAlerts` (GitHub Security Advisories)
- Enable `osvVulnerabilityAlerts` (OSV db — covers crates.io properly, unlike Dependabot)
- Security PRs: label `security`, priority 10, auto-merge, no release-age delay

## Why
Renovate's security coverage is a superset of Dependabot's (adds Rust/crates.io via OSV), groups updates, rebases on its own, and understands monorepos. Dependabot security updates are disabled on each repo after this lands.

## Test plan
- [ ] Merge preset
- [ ] Disable Dependabot security updates across all FerrLabs repos
- [ ] Verify Renovate picks up next CVE as a PR with `security` label