### PR TITLE
docs(profile): rewrite org README — public repos only, friendlier tone

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,35 +4,58 @@
 
 **Developer tools for teams that ship.**
 
-[ferrlabs.com](https://ferrlabs.com) · [ferrflow.com](https://ferrflow.com) · [ferrvault.com](https://ferrvault.com)
+[ferrlabs.com](https://ferrlabs.com) · [ferrflow.com](https://ferrflow.com)
 
 </div>
 
 ---
 
-## Products
+We build small, opinionated CLIs and self-hostable backends for the parts of the dev workflow you should not have to think about. Open source where it makes sense, paid SaaS or self-host when you need more.
 
-### [FerrFlow](https://ferrflow.com)
-Universal semantic versioning for monorepos and classic repos. One binary, any language, git-driven releases.
+## Open source
 
-Free and open source. Drop it into your CI and let conventional commits drive your version bumps, changelogs, and GitHub releases.
+### [FerrFlow](https://github.com/FerrLabs/FerrFlow) · v4
 
-**Repo:** [FerrLabs/FerrFlow](https://github.com/FerrLabs/FerrFlow)
+Universal semantic versioning. One Rust binary reads your conventional commits, bumps versions across your monorepo (14+ file formats — Cargo.toml, package.json, pyproject.toml, Chart.yaml, mix.exs, gemspec, pubspec.yaml, …), generates changelogs, tags, and ships GitHub releases. Free, MPL-2.0, drop into any CI.
 
-### [FerrVault](https://ferrvault.com)
-Secrets management without the infrastructure. CLI-native, zero Vault servers to deploy, with a Kubernetes operator for native Secret sync.
+```bash
+cargo install ferrflow
+# or
+uses: FerrLabs/FerrFlow@v4
+```
 
-**Repos:** [FerrLabs/FerrVault](https://github.com/FerrLabs/FerrVault) (K8s operator) · backend in [FerrLabs/Core](https://github.com/FerrLabs/Core)
+→ [Docs & playground at ferrflow.com](https://ferrflow.com)
+
+### [FerrVault Operator](https://github.com/FerrLabs/FerrVault)
+
+Kubernetes operator (Go) that syncs FerrVault SaaS secrets into native `kind: Secret`. Two CRDs — `FerrVaultConnection` + `FerrVaultSecret`. Pairs with the FerrVault SaaS but works equally well against a self-hosted FerrVault.
+
+### Tooling around FerrFlow
+
+- **[Fixtures](https://github.com/FerrLabs/Fixtures)** — declarative git fixture generator. Spin up reproducible repos in CI for integration tests and benchmarks.
+- **[Benchmarks](https://github.com/FerrLabs/Benchmarks)** — reusable GitHub Action that runs the FerrFlow perf suite and reports regressions on every PR.
+
+## Coming soon
+
+| | What | Status |
+|---|---|---|
+| **FerrVault** | Secrets management without the infra. SaaS or self-host, K8s-native via the operator above. | beta |
+| **FerrTrack** | Issue tracker for product teams. Keyboard-first, git-aware, no SLAs or AI summaries you didn't ask for. | soon |
+| **FerrGrowth** | Marketing sites with built-in SEO, performance budgets, content automation. | soon |
+
+The web apps for these live behind closed doors today; the open-source pieces (operators, CLIs, shared crates) land here as they ship.
+
+## Principles
+
+- **CLIs over UIs.** The terminal is the original keyboard shortcut.
+- **Self-host is a feature.** Your data, your cluster, your problem to solve.
+- **Open source where it makes sense.** The infra layer should be readable.
+- **No telemetry by default.** Off until you opt in.
 
 ---
 
-## Core infrastructure
+<div align="center">
 
-- **[Core](https://github.com/FerrLabs/Core)** — shared backend, web apps, admin, marketing sites
-- **[MCP](https://github.com/FerrLabs/MCP)** — Model Context Protocol server for AI-assisted workflows
-- **[Benchmarks](https://github.com/FerrLabs/Benchmarks)** — performance test harness for FerrFlow
-- **[Fixtures](https://github.com/FerrLabs/Fixtures)** — declarative git fixture generator for integration tests
+Built in Rust, Go, and TypeScript · MPL-2.0 where applicable · Hand-built in Lille, FR
 
----
-
-Built in Rust, Go, and TypeScript. Self-hostable by design.
+</div>


### PR DESCRIPTION
Old README linked to private repos (`Core`, `MCP`) and to a non-existent `ferrvault.com` — visitors hitting github.com/FerrLabs would get 404s.

New version:
- Mentions only **public** repos: FerrFlow (CLI), FerrVault (K8s operator only), Fixtures, Benchmarks.
- Frames FerrVault/FerrTrack/FerrGrowth as "coming soon" without linking to the closed web app code.
- Adds a one-line install snippet for FerrFlow up top so visitors can try it in 30 seconds.
- Drops the corporate "Products / Core infrastructure" structure for a friendlier "Open source / Coming soon / Principles" flow.
- Same footer feel as the marketing sites: "Hand-built in Lille, FR".