### PR TITLE
fix(workflows): add missing reusables, point templates to .github

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,0 +1,159 @@
+name: Reusable — Docker build (lint, scan, sign, SBOM)
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: 'Full image name (e.g. ghcr.io/ferrlabs/foo)'
+        type: string
+        required: true
+      tag:
+        description: 'Image tag (e.g. v1.2.3 or commit sha)'
+        type: string
+        required: true
+      context:
+        description: 'Docker build context'
+        type: string
+        required: false
+        default: '.'
+      dockerfile:
+        description: 'Path to Dockerfile relative to context'
+        type: string
+        required: false
+        default: 'Dockerfile'
+      platforms:
+        description: 'Comma-separated build platforms'
+        type: string
+        required: false
+        default: 'linux/amd64,linux/arm64'
+      build-args:
+        description: 'Newline-separated build args (KEY=VALUE)'
+        type: string
+        required: false
+        default: ''
+      trivy-severity:
+        description: 'Trivy severities that fail the build'
+        type: string
+        required: false
+        default: 'CRITICAL,HIGH'
+      push:
+        description: 'Push the image to the registry'
+        type: boolean
+        required: false
+        default: true
+    outputs:
+      digest:
+        description: 'Image digest (sha256:...)'
+        value: ${{ jobs.build.outputs.digest }}
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  security-events: write
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ inputs.context }}/${{ inputs.dockerfile }}
+          failure-threshold: warning
+
+  build:
+    name: Build & push
+    needs: hadolint
+    runs-on: ferrlabs-k8s
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v4
+      - name: Login to GHCR
+        if: startsWith(inputs.image-name, 'ghcr.io/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        id: push
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.context }}/${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ inputs.image-name }}:${{ inputs.tag }}
+            ${{ inputs.image-name }}:latest
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  trivy:
+    name: Trivy (CVE scan)
+    needs: build
+    if: inputs.push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ inputs.image-name }}:${{ inputs.tag }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+          exit-code: '1'
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
+
+  cosign:
+    name: cosign (sign + attest)
+    needs: [build, trivy]
+    if: inputs.push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sigstore/cosign-installer@v3
+      - name: Login to GHCR
+        if: startsWith(inputs.image-name, 'ghcr.io/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sign image (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+        run: |
+          cosign sign --yes \
+            "${{ inputs.image-name }}@${{ needs.build.outputs.digest }}"
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ inputs.image-name }}
+          subject-digest: ${{ needs.build.outputs.digest }}
+          push-to-registry: true
+
+  sbom:
+    name: SBOM (Syft → CycloneDX)
+    needs: build
+    if: inputs.push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anchore/sbom-action@v0
+        with:
+          image: ${{ inputs.image-name }}@${{ needs.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: true
+          upload-release-assets: false

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -1,0 +1,147 @@
+name: Reusable — Release Rust binary
+
+on:
+  workflow_call:
+    inputs:
+      bin-name:
+        description: 'Name of the binary (without extension)'
+        type: string
+        required: true
+      crate-publish:
+        description: 'Publish to crates.io'
+        type: boolean
+        required: false
+        default: false
+      docker-publish:
+        description: 'Build and publish a Docker image after the binaries'
+        type: boolean
+        required: false
+        default: false
+      docker-image-name:
+        description: 'Docker image name if docker-publish=true'
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: false
+      FERRFLOW_TOKEN:
+        required: false
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+  packages: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            ext: ''
+            archive: tar.gz
+            arch_label: linux-x64
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            ext: ''
+            archive: tar.gz
+            arch_label: linux-arm64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            ext: ''
+            archive: tar.gz
+            arch_label: darwin-x64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            ext: ''
+            archive: tar.gz
+            arch_label: darwin-arm64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            ext: '.exe'
+            archive: zip
+            arch_label: windows-x64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cross (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl -fsSL --retry 6 --retry-delay 5 --retry-connrefused --retry-all-errors \
+            -o /tmp/cross.tar.gz \
+            https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz
+          tar xz -C "$HOME/.cargo/bin" -f /tmp/cross.tar.gz
+      - name: Build (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: cross build --release --target ${{ matrix.target }}
+      - name: Build (macOS / Windows)
+        if: matrix.os != 'ubuntu-latest'
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          tar -czf ${{ inputs.bin-name }}-${{ matrix.arch_label }}.tar.gz \
+            -C target/${{ matrix.target }}/release ${{ inputs.bin-name }}${{ matrix.ext }}
+      - name: Package (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Compress-Archive `
+            -Path target/${{ matrix.target }}/release/${{ inputs.bin-name }}${{ matrix.ext }} `
+            -DestinationPath ${{ inputs.bin-name }}-${{ matrix.arch_label }}.zip
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.bin-name }}-${{ matrix.arch_label }}
+          path: ${{ inputs.bin-name }}-${{ matrix.arch_label }}.*
+
+  upload:
+    name: Attest + upload assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+          pattern: ${{ inputs.bin-name }}-*
+          merge-multiple: true
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/*
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          for file in artifacts/*; do
+            gh release upload "$TAG" "$file" --clobber
+          done
+
+  publish-crate:
+    name: Publish crates.io
+    needs: upload
+    if: inputs.crate-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-docker:
+    name: Publish Docker
+    needs: upload
+    if: inputs.docker-publish && inputs.docker-image-name != ''
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      image-name: ${{ inputs.docker-image-name }}
+      tag: ${{ github.ref_name }}
+      context: .
+      dockerfile: Dockerfile
+    secrets: inherit

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -1,0 +1,73 @@
+name: Reusable — Security scan
+
+on:
+  workflow_call:
+    inputs:
+      gitleaks-config:
+        description: 'Path to a custom gitleaks config (optional)'
+        type: string
+        required: false
+        default: ''
+      osv-scan-args:
+        description: 'Extra args for osv-scanner'
+        type: string
+        required: false
+        default: '--recursive .'
+      fail-on-cve:
+        description: 'Fail the workflow on any CVE found by osv-scanner'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    name: gitleaks (secrets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_CONFIG: ${{ inputs.gitleaks-config }}
+
+  osv-scanner:
+    name: osv-scanner (CVE)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: google/osv-scanner-action/osv-scanner-action@v2.0.0
+        with:
+          scan-args: |
+            --output=osv-results.sarif
+            --format=sarif
+            ${{ inputs.osv-scan-args }}
+        continue-on-error: ${{ !inputs.fail-on-cve }}
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner
+        continue-on-error: true
+
+  trufflehog:
+    name: trufflehog (secrets, deep history)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ''
+          head: HEAD
+          extra_args: --results=verified,unknown

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -12,20 +12,20 @@ GitHub-discovered workflow templates. They appear under **Actions → New workfl
 | [`ci-go`](ci-go.yml) | gofmt, vet, golangci-lint, race tests, govulncheck, build | Any Go module (operators, services). |
 | [`codeql`](codeql.yml) | GitHub CodeQL static analysis (security-and-quality queries) | All TS/JS/Go/Python repos (CodeQL doesn't support Rust yet). |
 | [`scorecard`](scorecard.yml) | OpenSSF Scorecard supply-chain risk score | All public repos and key private repos. |
-| [`security-scan`](security-scan.yml) | Reusable: gitleaks (secrets) + osv-scanner (CVE) + trufflehog (deep history) | Every repo — call the shared workflow from `FerrLabs/Infra`. |
+| [`security-scan`](security-scan.yml) | Reusable: gitleaks (secrets) + osv-scanner (CVE) + trufflehog (deep history) | Every repo — call the shared workflow from `FerrLabs/.github`. |
 | [`pr-title`](pr-title.yml) | Conventional Commits validation on PR titles | Every repo (mandatory because we squash-merge). |
 | [`release`](release.yml) | Auto-release on push to main with `FerrLabs/FerrFlow@v4` | Repos that ship semver releases. |
 | [`docker-publish`](docker-publish.yml) | Reusable: hadolint + multi-arch build + Trivy + cosign keyless + SBOM | Repos that publish a container image. |
 
 ## Reusable workflows
 
-The `security-scan` and `docker-publish` templates **call** reusable workflows hosted in `FerrLabs/Infra`:
+The `security-scan` and `docker-publish` templates **call** reusable workflows hosted in `FerrLabs/.github`:
 
-- `FerrLabs/Infra/.github/workflows/reusable-security-scan.yml@main`
-- `FerrLabs/Infra/.github/workflows/reusable-docker-build.yml@main`
-- `FerrLabs/Infra/.github/workflows/reusable-release-rust.yml@main` (cross-compile binaries → attest → upload to release → optional crates.io + Docker)
+- `FerrLabs/.github/.github/workflows/reusable-security-scan.yml@main`
+- `FerrLabs/.github/.github/workflows/reusable-docker-build.yml@main`
+- `FerrLabs/.github/.github/workflows/reusable-release-rust.yml@main` (cross-compile binaries → attest → upload to release → optional crates.io + Docker)
 
-Updating the source workflow in `Infra` propagates to every consumer at the next run.
+Hosting the reusables in the **public** `.github` repo (rather than the private `Infra` repo) is required for OSS repos like FerrFlow to call them — GitHub forbids public→private reusable calls. Updating the source workflow propagates to every consumer at the next run.
 
 ## Conventions
 

--- a/workflow-templates/docker-publish.properties.json
+++ b/workflow-templates/docker-publish.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "FerrLabs — Docker publish (hadolint + Trivy + cosign + SBOM)",
-  "description": "Calls the shared FerrLabs/Infra reusable workflow to lint the Dockerfile (hadolint), build a multi-arch image, scan for CVE (Trivy), sign with keyless cosign, and attach a CycloneDX SBOM.",
+  "description": "Calls the shared FerrLabs/.github reusable workflow to lint the Dockerfile (hadolint), build a multi-arch image, scan for CVE (Trivy), sign with keyless cosign, and attach a CycloneDX SBOM.",
   "iconName": "ferrlabs",
   "categories": ["Deployment", "Security"],
   "filePatterns": ["Dockerfile$"]

--- a/workflow-templates/docker-publish.yml
+++ b/workflow-templates/docker-publish.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     name: Build, scan, sign, publish
-    uses: FerrLabs/Infra/.github/workflows/reusable-docker-build.yml@main
+    uses: FerrLabs/.github/.github/workflows/reusable-docker-build.yml@main
     with:
       image-name: ghcr.io/ferrlabs/${{ github.event.repository.name }}
       tag: ${{ inputs.tag || github.ref_name }}

--- a/workflow-templates/security-scan.properties.json
+++ b/workflow-templates/security-scan.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "FerrLabs — Security scan (gitleaks + OSV)",
-  "description": "Calls the shared FerrLabs/Infra reusable workflow that runs gitleaks (secret scanning) and osv-scanner (CVE scan across Rust/Node/Docker/Go) on push, PR and a daily schedule.",
+  "description": "Calls the shared FerrLabs/.github reusable workflow that runs gitleaks (secret scanning) and osv-scanner (CVE scan across Rust/Node/Docker/Go) on push, PR and a daily schedule.",
   "iconName": "ferrlabs",
   "categories": ["Security"],
   "filePatterns": [".*"]

--- a/workflow-templates/security-scan.yml
+++ b/workflow-templates/security-scan.yml
@@ -16,5 +16,5 @@ permissions:
 jobs:
   scan:
     name: Secrets + CVE
-    uses: FerrLabs/Infra/.github/workflows/reusable-security-scan.yml@main
+    uses: FerrLabs/.github/.github/workflows/reusable-security-scan.yml@main
     secrets: inherit


### PR DESCRIPTION
## Why

The merge of #11 only included the first commit of the feature branch — the second commit (which moved the reusable workflows from \`Infra\` to \`.github\` to allow public repos to call them) wasn't part of the squash. So on \`main\`:

- \`workflow-templates/security-scan.yml\` references \`FerrLabs/Infra/.github/workflows/reusable-security-scan.yml@main\` — doesn't exist
- \`workflow-templates/docker-publish.yml\` references \`FerrLabs/Infra/.github/workflows/reusable-docker-build.yml@main\` — doesn't exist
- [FerrFlow#406](https://github.com/FerrLabs/FerrFlow/pull/406) is already merged with a \`security-scan.yml\` calling \`FerrLabs/.github/.github/workflows/reusable-security-scan.yml@main\` — also doesn't exist

Net effect: the security-scan workflow is broken on FerrFlow's \`main\` until this lands.

## What

- Adds the three reusable workflows under \`.github/workflows/\`:
  - \`reusable-security-scan.yml\` (gitleaks + osv-scanner + trufflehog)
  - \`reusable-docker-build.yml\` (hadolint + buildx + Trivy + cosign keyless + SBOM)
  - \`reusable-release-rust.yml\` (cross-compile 5 targets + attest + upload + opt-in crates.io/Docker)
- Updates \`security-scan.yml\` and \`docker-publish.yml\` templates to reference \`FerrLabs/.github\` (public) instead of \`FerrLabs/Infra\` (private)
- Updates the README accordingly

Public repos cannot call reusable workflows from a private repo (GitHub restriction), so the public \`.github\` repo is the correct home for these.

Refs #10