### PR TITLE
fix(security-scan): use OSS gitleaks binary + filesystem trufflehog

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -31,11 +31,28 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Install gitleaks
+        run: |
+          VERSION=8.21.2
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Run gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           GITLEAKS_CONFIG: ${{ inputs.gitleaks-config }}
+        run: |
+          ARGS=(detect --source . --redact --verbose --report-format sarif --report-path gitleaks.sarif)
+          if [ -n "$GITLEAKS_CONFIG" ]; then
+            ARGS+=(--config "$GITLEAKS_CONFIG")
+          fi
+          gitleaks "${ARGS[@]}"
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+        continue-on-error: true
 
   osv-scanner:
     name: osv-scanner (CVE)
@@ -65,9 +82,25 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: trufflesecurity/trufflehog@main
+      - name: Install trufflehog
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+            | sh -s -- -b /usr/local/bin
+          trufflehog --version
+      - name: Run trufflehog (filesystem + git history)
+        run: |
+          trufflehog git file://. --only-verified --fail --no-update --json > trufflehog.json || EXIT=$?
+          echo "trufflehog exit: ${EXIT:-0}"
+          if [ -s trufflehog.json ]; then
+            echo "::warning::trufflehog found verified secrets — see artifact"
+            jq -r '. | "\(.SourceMetadata.Data.Git.repository) \(.DetectorName) \(.Raw)"' trufflehog.json | head -20
+          fi
+          exit "${EXIT:-0}"
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
-          path: ./
-          base: ''
-          head: HEAD
-          extra_args: --results=verified,unknown
+          name: trufflehog-findings
+          path: trufflehog.json
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Why

FerrFlow's first run of \`security-scan\` on \`main\` exposed two real problems in the reusable: [run 25257306977](https://github.com/FerrLabs/FerrFlow/actions/runs/25257306977).

- **\`gitleaks-action@v2\`** is now a paid commercial product for organizations. It claims to be free for public repos, but the auto-detection is broken for org-owned public repos (FerrFlow is one) and the action exits with \`missing gitleaks license\`.
- **\`trufflesecurity/trufflehog@main\`** action fails with \`BASE and HEAD commits are the same\` whenever it's invoked on \`workflow_dispatch\` from the default branch — which is exactly when we want the deep scan to run.

## What

Both jobs now install the upstream OSS binary directly and run it inline:

- **gitleaks**: \`gitleaks detect --report-format sarif\` → SARIF uploaded to code scanning. No license, no third-party action.
- **trufflehog**: \`trufflehog git file://.\` (filesystem mode, full history) with \`--only-verified --fail\`. Findings JSON kept as an artifact for 14 days when present.

\`osv-scanner\` was already using the upstream action and worked fine — left unchanged.

## Test plan

- [ ] After merge, re-run \`security-scan\` on FerrFlow main and verify all three jobs succeed
- [ ] Verify gitleaks SARIF appears under Security → Code scanning → \`gitleaks\` category