### PR TITLE
fix(security-scan): install Go toolchain when go.mod is present

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -59,6 +59,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Detect Go module
+        id: detect
+        run: |
+          if [ -f go.mod ] || find . -name go.mod -not -path './.git/*' -not -path './node_modules/*' | grep -q .; then
+            echo "has_go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_go=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/setup-go@v6
+        if: steps.detect.outputs.has_go == 'true'
+        with:
+          go-version: stable
+          cache: false
       - uses: google/osv-scanner-action/osv-scanner-action@v2.0.0
         with:
           scan-args: |


### PR DESCRIPTION
Regression spotted during the rollout to FerrVault operator: osv-scanner needs the Go toolchain to resolve the transitive module graph from `go.mod` (unlike npm/cargo/pip which work from lockfiles alone). Without it, the job exits with `the Go toolchain is required`.

[FerrVault#72 osv-scanner failure](https://github.com/FerrLabs/FerrVault/pull/72)

Detect → setup-go conditionally so non-Go repos don't pay the ~10s setup cost.