### PR TITLE
fix(security-scan): install osv-scanner binary directly instead of Docker action

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -72,15 +72,26 @@ jobs:
         with:
           go-version: stable
           cache: false
-      - uses: google/osv-scanner-action/osv-scanner-action@v2.0.0
-        with:
-          scan-args: |
-            --output=osv-results.sarif
-            --format=sarif
-            ${{ inputs.osv-scan-args }}
-        continue-on-error: ${{ !inputs.fail-on-cve }}
+        env:
+          GOTOOLCHAIN: auto
+      - name: Install osv-scanner
+        run: |
+          VERSION=2.0.2
+          curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${VERSION}/osv-scanner_linux_amd64" \
+            -o /usr/local/bin/osv-scanner
+          chmod +x /usr/local/bin/osv-scanner
+          osv-scanner --version
+      - name: Run osv-scanner
+        run: |
+          set +e
+          osv-scanner scan --output=osv-results.sarif --format=sarif ${{ inputs.osv-scan-args }}
+          EXIT=$?
+          set -e
+          if [ "${{ inputs.fail-on-cve }}" = "true" ]; then
+            exit $EXIT
+          fi
       - name: Upload SARIF
-        if: always()
+        if: always() && hashFiles('osv-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: osv-results.sarif


### PR DESCRIPTION
Second-order regression: even after [#15](https://github.com/FerrLabs/.github/pull/15) installed Go on the runner, the operator's osv-scanner job still failed because `google/osv-scanner-action@v2.0.0` runs **inside a Docker container** with its own bundled Go (1.23.7) — the host's setup-go is invisible to it. The operator's go.mod requires Go >= 1.26.0 → `go.mod requires go >= 1.26.0 (running go 1.23.7; GOTOOLCHAIN=local)`.

Same pattern as the gitleaks-action and trufflehog-action problems: third-party action wrappers add fragility we don't need. Switch to the upstream binary, which uses the host's setup-go toolchain naturally and respects GOTOOLCHAIN=auto for transitive Go-version requirements.