### PR TITLE
fix(security-scan): disable osv-scanner call analysis (Go version skew)

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -84,7 +84,10 @@ jobs:
       - name: Run osv-scanner
         run: |
           set +e
-          osv-scanner scan --output=osv-results.sarif --format=sarif ${{ inputs.osv-scan-args }}
+          osv-scanner scan source \
+            --output=osv-results.sarif --format=sarif \
+            --call-analysis=none \
+            ${{ inputs.osv-scan-args }}
           EXIT=$?
           set -e
           if [ "${{ inputs.fail-on-cve }}" = "true" ]; then


### PR DESCRIPTION
Third regression chase on the osv-scanner Go path. The binary itself is built with Go 1.24 — when scanning source for newer projects (operator uses Go 1.26), `go list` fails because osv-scanner's bundled processing can't read newer language features.

Solutions tried:
1. [#15](https://github.com/FerrLabs/.github/pull/15) installed Go on the runner — didn't help, action ran in Docker container with own Go
2. [#16](https://github.com/FerrLabs/.github/pull/16) switched to osv-scanner binary on host — uncovered the binary's own Go-1.24 limit
3. **This PR**: disable call-analysis, fall back to dependency-version checks against the OSV API

Govulncheck (in the `ci-go` workflow template) already provides code-aware Go vulnerability scanning — better-suited than osv-scanner for Go. So disabling osv-scanner's call-analysis is not a coverage loss when both workflows are in place.