### PR TITLE
fix(security-scan): default fail-on-cve to false + add actions:read permission

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -17,11 +17,12 @@ on:
         description: 'Fail the workflow on any CVE found by osv-scanner'
         type: boolean
         required: false
-        default: true
+        default: false
 
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Rollout uncovered two adjustments:

1. Real CVE findings on most Node-based repos (transitive deps with advisories) made the scan blocking by default, breaking all PRs. Flipping default to non-blocking — findings still appear in the Security tab, repos can opt into strict mode explicitly.

2. `upload-sarif` was failing with `Resource not accessible by integration` because `actions: read` was missing from the permissions block.

Refs #14