### PR TITLE
fix(security-scan): revert actions:read to unblock all consumer workflows

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -22,7 +22,6 @@ on:
 permissions:
   contents: read
   security-events: write
-  actions: read
 
 jobs:
   gitleaks:


### PR DESCRIPTION
PR #19 added `actions: read` to the reusable's permissions, which silently broke every consumer because GitHub enforces caller permissions ≥ reusable permissions. All 15 deployed consumers had only `contents: read` + `security-events: write` and started failing at workflow startup.

The original 'Resource not accessible by integration' on upload-sarif was a non-fatal warning we can live with. Reverting the requirement.

Refs #14