### PR TITLE
feat(workflows): add reusable-ci-{rust,node,astro,go} (parameterised)

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -1,0 +1,165 @@
+name: Reusable — CI Astro Site
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Astro project root'
+        type: string
+        default: '.'
+      runner:
+        description: 'GitHub Actions runner label'
+        type: string
+        default: 'ferrlabs-k8s'
+      node-version:
+        type: string
+        default: '24'
+      pnpm-version:
+        type: string
+        default: '10'
+      install-args:
+        type: string
+        default: '--frozen-lockfile'
+      registry-url:
+        type: string
+        default: 'https://npm.pkg.github.com'
+      registry-scope:
+        type: string
+        default: '@ferrlabs'
+      astro-check-args:
+        description: 'Extra args for astro check'
+        type: string
+        default: ''
+      lint-script:
+        type: string
+        default: 'lint'
+      build-script:
+        type: string
+        default: 'build'
+      i18n-script:
+        description: 'Script name for i18n parity check (omit if not present)'
+        type: string
+        default: 'check:i18n'
+      dist-path:
+        description: 'Path to built dist (relative to working-directory)'
+        type: string
+        default: 'dist'
+      enable-astro-check:
+        type: boolean
+        default: true
+      enable-lint:
+        type: boolean
+        default: true
+      enable-build:
+        type: boolean
+        default: true
+      enable-i18n:
+        type: boolean
+        default: true
+      enable-lighthouse:
+        description: 'Run Lighthouse CI on PRs (requires LHCI_GITHUB_APP_TOKEN secret)'
+        type: boolean
+        default: false
+      lighthouse-only-pr:
+        description: 'Run Lighthouse only on pull_request events'
+        type: boolean
+        default: true
+      lighthouse-version:
+        type: string
+        default: '0.14.x'
+    secrets:
+      FERRLABS_PACKAGES_READ:
+        required: false
+      LHCI_GITHUB_APP_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & Check
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ inputs.pnpm-version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: pnpm
+          cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
+          registry-url: ${{ inputs.registry-url }}
+          scope: ${{ inputs.registry-scope }}
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+        run: pnpm install ${{ inputs.install-args }}
+      - name: Astro check
+        if: inputs.enable-astro-check
+        run: pnpm exec astro check ${{ inputs.astro-check-args }}
+      - name: Lint
+        if: inputs.enable-lint
+        run: pnpm run ${{ inputs.lint-script }}
+      - name: Build
+        if: inputs.enable-build
+        run: pnpm run ${{ inputs.build-script }}
+      - name: Upload dist (for downstream Lighthouse)
+        if: inputs.enable-build && inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
+        uses: actions/upload-artifact@v7
+        with:
+          name: site-dist
+          path: ${{ inputs.working-directory }}/${{ inputs.dist-path }}
+          retention-days: 1
+
+  i18n:
+    name: i18n parity
+    if: inputs.enable-i18n
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ inputs.pnpm-version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: pnpm
+          cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
+          registry-url: ${{ inputs.registry-url }}
+          scope: ${{ inputs.registry-scope }}
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+        run: pnpm install ${{ inputs.install-args }}
+      - name: Check i18n parity
+        run: pnpm run ${{ inputs.i18n-script }}
+        continue-on-error: true
+
+  lighthouse:
+    name: Lighthouse CI
+    needs: build
+    if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: site-dist
+          path: ${{ inputs.dist-path }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Run Lighthouse
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+        run: |
+          npm install -g @lhci/cli@${{ inputs.lighthouse-version }}
+          lhci autorun --collect.staticDistDir=${{ inputs.dist-path }} || true

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -1,0 +1,208 @@
+name: Reusable — CI Go
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Module root (for non-root or multi-module repos)'
+        type: string
+        default: '.'
+      runner:
+        description: 'GitHub Actions runner label'
+        type: string
+        default: 'ubuntu-latest'
+      go-version-file:
+        description: 'Path to go.mod (relative to working-directory)'
+        type: string
+        default: 'go.mod'
+      go-version:
+        description: 'Override Go version (takes precedence over go-version-file if set)'
+        type: string
+        default: ''
+      golangci-version:
+        type: string
+        default: 'latest'
+      build-paths:
+        description: 'Packages to build (default ./...)'
+        type: string
+        default: './...'
+      test-paths:
+        description: 'Packages to test (default ./...)'
+        type: string
+        default: './...'
+      enable-fmt:
+        type: boolean
+        default: true
+      enable-vet:
+        type: boolean
+        default: true
+      enable-lint:
+        type: boolean
+        default: true
+      enable-test:
+        type: boolean
+        default: true
+      enable-race:
+        description: 'Run go test with -race'
+        type: boolean
+        default: true
+      enable-coverage:
+        type: boolean
+        default: true
+      enable-vulncheck:
+        description: 'Run govulncheck'
+        type: boolean
+        default: true
+      enable-build:
+        type: boolean
+        default: true
+      skip-on-release-commit:
+        description: 'Skip checks on push commits starting with chore(release):'
+        type: boolean
+        default: true
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect Go module
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    outputs:
+      has_go: ${{ steps.check.outputs.has_go }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: check
+        run: |
+          if [ -f "${{ inputs.go-version-file }}" ]; then
+            echo "has_go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_go=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint:
+    name: Lint
+    needs: detect
+    if: |
+      needs.detect.outputs.has_go == 'true' && (inputs.enable-fmt || inputs.enable-vet || inputs.enable-lint) && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: true
+      - name: gofmt
+        if: inputs.enable-fmt
+        run: |
+          diff=$(gofmt -l .)
+          if [ -n "$diff" ]; then
+            echo "Files need gofmt:"
+            echo "$diff"
+            exit 1
+          fi
+      - name: go vet
+        if: inputs.enable-vet
+        run: go vet ${{ inputs.test-paths }}
+      - if: inputs.enable-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ inputs.golangci-version }}
+          working-directory: ${{ inputs.working-directory }}
+
+  test:
+    name: Test
+    needs: detect
+    if: |
+      needs.detect.outputs.has_go == 'true' && inputs.enable-test && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: true
+      - name: Test
+        run: |
+          ARGS=""
+          if [ "${{ inputs.enable-race }}" = "true" ]; then ARGS="$ARGS -race"; fi
+          if [ "${{ inputs.enable-coverage }}" = "true" ]; then ARGS="$ARGS -coverprofile=coverage.out"; fi
+          go test $ARGS ${{ inputs.test-paths }}
+      - if: inputs.enable-coverage
+        uses: codecov/codecov-action@v6
+        with:
+          files: ${{ inputs.working-directory }}/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+  security:
+    name: Security
+    needs: detect
+    if: |
+      needs.detect.outputs.has_go == 'true' && inputs.enable-vulncheck && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: true
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ${{ inputs.test-paths }}
+
+  build:
+    name: Build
+    needs: [detect, lint, test]
+    if: |
+      always() && needs.detect.outputs.has_go == 'true' && inputs.enable-build &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      (needs.test.result == 'success' || needs.test.result == 'skipped') && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: true
+      - name: Build
+        run: go build -o bin/ ${{ inputs.build-paths }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -1,0 +1,177 @@
+name: Reusable — CI Node/TypeScript
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Package root (for monorepos / nested packages)'
+        type: string
+        default: '.'
+      runner:
+        description: 'GitHub Actions runner label'
+        type: string
+        default: 'ferrlabs-k8s'
+      node-version:
+        description: 'Node.js version'
+        type: string
+        default: '24'
+      pnpm-version:
+        description: 'pnpm version'
+        type: string
+        default: '10'
+      package-manager:
+        description: 'Package manager (pnpm, npm, yarn)'
+        type: string
+        default: 'pnpm'
+      install-args:
+        description: 'Extra args for the install command (e.g. --filter for monorepo)'
+        type: string
+        default: '--frozen-lockfile'
+      registry-url:
+        description: 'npm registry URL for scoped packages'
+        type: string
+        default: 'https://npm.pkg.github.com'
+      registry-scope:
+        description: 'Scope to attach to the registry (e.g. @ferrlabs)'
+        type: string
+        default: '@ferrlabs'
+      typecheck-script:
+        description: 'Script name for typecheck (in package.json)'
+        type: string
+        default: 'typecheck'
+      lint-script:
+        description: 'Script name for lint'
+        type: string
+        default: 'lint'
+      test-script:
+        description: 'Script name for tests with coverage'
+        type: string
+        default: 'test:coverage'
+      build-script:
+        description: 'Script name for build'
+        type: string
+        default: 'build'
+      enable-typecheck:
+        type: boolean
+        default: true
+      enable-lint:
+        type: boolean
+        default: true
+      enable-test:
+        type: boolean
+        default: true
+      enable-build:
+        type: boolean
+        default: true
+      enable-knip:
+        description: 'Run knip (dead code, unused exports & deps)'
+        type: boolean
+        default: true
+      enable-madge:
+        description: 'Run madge --circular'
+        type: boolean
+        default: true
+      madge-paths:
+        description: 'Path(s) for madge to scan'
+        type: string
+        default: 'src'
+      enable-audit:
+        description: 'Run package-manager audit'
+        type: boolean
+        default: true
+      audit-level:
+        description: 'Audit severity threshold (low, moderate, high, critical)'
+        type: string
+        default: 'high'
+      coverage-upload:
+        description: 'Upload coverage to Codecov'
+        type: boolean
+        default: true
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+      FERRLABS_PACKAGES_READ:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@v5
+        with:
+          version: ${{ inputs.pnpm-version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+          cache-dependency-path: ${{ inputs.working-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
+          registry-url: ${{ inputs.registry-url }}
+          scope: ${{ inputs.registry-scope }}
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+        run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
+      - name: Typecheck
+        if: inputs.enable-typecheck
+        run: ${{ inputs.package-manager }} run ${{ inputs.typecheck-script }}
+      - name: Lint
+        if: inputs.enable-lint
+        run: ${{ inputs.package-manager }} run ${{ inputs.lint-script }}
+      - name: Test
+        if: inputs.enable-test
+        run: ${{ inputs.package-manager }} run ${{ inputs.test-script }}
+      - name: Upload coverage
+        if: inputs.enable-test && inputs.coverage-upload
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          working-directory: ${{ inputs.working-directory }}
+      - name: Build
+        if: inputs.enable-build
+        run: ${{ inputs.package-manager }} run ${{ inputs.build-script }}
+
+  quality:
+    name: Quality (knip, madge, audit)
+    if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@v5
+        with:
+          version: ${{ inputs.pnpm-version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+          cache-dependency-path: ${{ inputs.working-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
+          registry-url: ${{ inputs.registry-url }}
+          scope: ${{ inputs.registry-scope }}
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+        run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
+      - name: knip
+        if: inputs.enable-knip
+        run: ${{ inputs.package-manager }} dlx knip --reporter compact
+        continue-on-error: true
+      - name: madge (circular imports)
+        if: inputs.enable-madge
+        run: ${{ inputs.package-manager }} dlx madge --circular --extensions ts,tsx,js,jsx ${{ inputs.madge-paths }}
+        continue-on-error: true
+      - name: audit
+        if: inputs.enable-audit
+        run: ${{ inputs.package-manager }} audit --prod --audit-level=${{ inputs.audit-level }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -1,0 +1,222 @@
+name: Reusable — CI Rust
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Crate root (for monorepos / non-root crates)'
+        type: string
+        default: '.'
+      runner:
+        description: 'GitHub Actions runner label'
+        type: string
+        default: 'ubuntu-latest'
+      rust-toolchain:
+        description: 'Rust toolchain (stable, nightly, beta, or pinned version)'
+        type: string
+        default: 'stable'
+      rust-components:
+        description: 'Comma-separated rustup components'
+        type: string
+        default: 'clippy, rustfmt'
+      rust-targets:
+        description: 'Comma-separated rustup targets (optional)'
+        type: string
+        default: ''
+      cargo-flags:
+        description: 'Flags appended to cargo invocations (clippy, test, build)'
+        type: string
+        default: '--all-features'
+      clippy-args:
+        description: 'Args after the `--` separator for clippy'
+        type: string
+        default: '-D warnings'
+      test-args:
+        description: 'Extra args for cargo test'
+        type: string
+        default: ''
+      check-fmt:
+        description: 'Run `cargo fmt --check`'
+        type: boolean
+        default: true
+      check-clippy:
+        description: 'Run cargo clippy'
+        type: boolean
+        default: true
+      run-tests:
+        description: 'Run cargo test'
+        type: boolean
+        default: true
+      enable-audit:
+        description: 'Run cargo audit (RustSec advisories)'
+        type: boolean
+        default: true
+      enable-deny:
+        description: 'Run cargo deny check (advisories + bans + licenses + sources)'
+        type: boolean
+        default: true
+      enable-machete:
+        description: 'Run cargo machete (unused deps)'
+        type: boolean
+        default: true
+      enable-typos:
+        description: 'Run typos-cli'
+        type: boolean
+        default: true
+      enable-coverage:
+        description: 'Generate coverage and upload to Codecov'
+        type: boolean
+        default: true
+      coverage-tool:
+        description: 'Coverage tool (llvm-cov or tarpaulin)'
+        type: string
+        default: 'llvm-cov'
+      cache:
+        description: 'Enable Swatinem/rust-cache'
+        type: boolean
+        default: true
+      skip-on-release-commit:
+        description: 'Skip checks on push commits starting with chore(release):'
+        type: boolean
+        default: true
+      ferrflow-hmac-secret-required:
+        description: 'Whether the FERRFLOW_HMAC_SECRET secret should be wired up (FerrFlow only)'
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+      FERRFLOW_HMAC_SECRET:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test
+    if: |
+      !inputs.skip-on-release-commit ||
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust-toolchain }}
+          components: ${{ inputs.rust-components }}
+          targets: ${{ inputs.rust-targets }}
+      - if: inputs.cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ inputs.working-directory }}
+      - name: Format check
+        if: inputs.check-fmt
+        run: cargo fmt --check
+      - name: Clippy
+        if: inputs.check-clippy
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+        run: cargo clippy ${{ inputs.cargo-flags }} -- ${{ inputs.clippy-args }}
+      - name: Tests
+        if: inputs.run-tests
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+        run: cargo test ${{ inputs.cargo-flags }} ${{ inputs.test-args }}
+
+  security:
+    name: Cargo Security
+    if: |
+      (inputs.enable-audit || inputs.enable-deny || inputs.enable-machete) && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust-toolchain }}
+      - if: inputs.cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ inputs.working-directory }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit,cargo-deny,cargo-machete
+      - name: cargo audit (RustSec advisories)
+        if: inputs.enable-audit
+        run: cargo audit --deny warnings
+      - name: cargo deny
+        if: inputs.enable-deny
+        run: cargo deny ${{ inputs.cargo-flags }} check
+      - name: cargo machete (unused deps)
+        if: inputs.enable-machete
+        run: cargo machete
+
+  typos:
+    name: Typos
+    if: inputs.enable-typos
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@master
+        with:
+          files: ${{ inputs.working-directory }}
+
+  coverage:
+    name: Coverage
+    if: |
+      inputs.enable-coverage && (
+        !inputs.skip-on-release-commit ||
+        github.event_name != 'push' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust-toolchain }}
+          components: llvm-tools-preview
+      - if: inputs.cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ inputs.working-directory }}
+      - if: inputs.coverage-tool == 'llvm-cov'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Generate coverage (llvm-cov)
+        if: inputs.coverage-tool == 'llvm-cov'
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+        run: cargo llvm-cov ${{ inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
+      - name: Generate coverage (tarpaulin)
+        if: inputs.coverage-tool == 'tarpaulin'
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out xml --skip-clean
+      - uses: codecov/codecov-action@v6
+        with:
+          files: ${{ inputs.coverage-tool == 'llvm-cov' && 'lcov.info' || 'cobertura.xml' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Adds 4 reusable CI workflows so each repo's ci.yml shrinks from ~80-200 lines to a 5-15 line caller. Highly parameterised:

- `working-directory` for monorepo nested packages
- `runner` (ubuntu-latest vs ferrlabs-k8s)
- per-job toggles (fmt/clippy/test/audit/deny/machete/typos/coverage on Rust; typecheck/lint/test/build/knip/madge/audit on Node; etc.)
- script names overridable
- toolchain versions pinned per caller

See [#22](https://github.com/FerrLabs/.github/issues/22) for migration plan. Pilots will follow on Kit (Rust), MCP (Node), FerrLabs-Cloud/site (Astro), ferrflow-operator (Go) before batching the remaining 12 repos.

Closes #22