### PR TITLE
fix(reusable-ci): make audit/govulncheck non-blocking by default

### DIFF
--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -53,6 +53,10 @@ on:
         description: 'Run govulncheck'
         type: boolean
         default: true
+      fail-on-vulncheck:
+        description: 'Fail the workflow on govulncheck findings (often unfixable upstream)'
+        type: boolean
+        default: false
       enable-build:
         type: boolean
         default: true
@@ -180,7 +184,16 @@ jobs:
       - name: govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
+          set +e
           govulncheck ${{ inputs.test-paths }}
+          EXIT=$?
+          set -e
+          if [ "${{ inputs.fail-on-vulncheck }}" = "true" ]; then
+            exit $EXIT
+          fi
+          if [ "$EXIT" != "0" ]; then
+            echo "::warning::govulncheck found vulnerabilities (non-blocking — set fail-on-vulncheck: true to act on them)"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -63,6 +63,18 @@ on:
         description: 'Run typos-cli'
         type: boolean
         default: true
+      fail-on-audit:
+        description: 'Fail the workflow on cargo audit advisories (often unfixable upstream)'
+        type: boolean
+        default: false
+      fail-on-machete:
+        description: 'Fail the workflow on cargo machete unused-dep findings'
+        type: boolean
+        default: true
+      audit-ignore:
+        description: 'Comma-separated RUSTSEC IDs to ignore (e.g. RUSTSEC-2023-0071)'
+        type: string
+        default: ''
       enable-coverage:
         description: 'Generate coverage and upload to Codecov'
         type: boolean
@@ -174,13 +186,39 @@ jobs:
           tool: cargo-audit,cargo-deny,cargo-machete
       - name: cargo audit (RustSec advisories)
         if: inputs.enable-audit
-        run: cargo audit --deny warnings
+        run: |
+          IGNORES=""
+          if [ -n "${{ inputs.audit-ignore }}" ]; then
+            for id in $(echo "${{ inputs.audit-ignore }}" | tr ',' ' '); do
+              IGNORES="$IGNORES --ignore $id"
+            done
+          fi
+          set +e
+          cargo audit --deny warnings $IGNORES
+          EXIT=$?
+          set -e
+          if [ "${{ inputs.fail-on-audit }}" = "true" ]; then
+            exit $EXIT
+          fi
+          if [ "$EXIT" != "0" ]; then
+            echo "::warning::cargo audit found advisories (non-blocking — set fail-on-audit: true or update audit-ignore to act on them)"
+          fi
       - name: cargo deny
         if: inputs.enable-deny
         run: cargo deny ${{ inputs.cargo-flags }} check
       - name: cargo machete (unused deps)
         if: inputs.enable-machete
-        run: cargo machete
+        run: |
+          set +e
+          cargo machete
+          EXIT=$?
+          set -e
+          if [ "${{ inputs.fail-on-machete }}" = "true" ]; then
+            exit $EXIT
+          fi
+          if [ "$EXIT" != "0" ]; then
+            echo "::warning::cargo machete found unused dependencies"
+          fi
 
   typos:
     name: Typos


### PR DESCRIPTION
Same pattern as fail-on-cve/fail-on-secret — pilots showed cargo audit and govulncheck find real but unfixable-upstream issues that block CI without value.

- ci-rust: `fail-on-audit` (default false), `fail-on-machete` (default true, unused deps are actionable), `audit-ignore` for pinned RUSTSEC waivers
- ci-go: `fail-on-vulncheck` (default false)

Refs #22