### PR TITLE
fix(reusable-ci-rust): default fail-on-machete to false

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -70,7 +70,7 @@ on:
       fail-on-machete:
         description: 'Fail the workflow on cargo machete unused-dep findings'
         type: boolean
-        default: true
+        default: false
       audit-ignore:
         description: 'Comma-separated RUSTSEC IDs to ignore (e.g. RUSTSEC-2023-0071)'
         type: string


### PR DESCRIPTION
Final default flip for consistency. Kit pilot caught real unused-dep findings — same pattern as audit / cve / secret findings, ship as warnings and let repos opt-in to strict.

Refs #22