### PR TITLE
fix(reusable-ci): rename secret to FERRFLOW_PACKAGES_READ

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -68,7 +68,7 @@ on:
         type: string
         default: '0.14.x'
     secrets:
-      FERRLABS_PACKAGES_READ:
+      FERRFLOW_PACKAGES_READ:
         required: false
       LHCI_GITHUB_APP_TOKEN:
         required: false
@@ -97,7 +97,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: pnpm install ${{ inputs.install-args }}
       - name: Astro check
         if: inputs.enable-astro-check
@@ -137,7 +137,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: pnpm install ${{ inputs.install-args }}
       - name: Check i18n parity
         run: pnpm run ${{ inputs.i18n-script }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -98,7 +98,7 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
-      FERRLABS_PACKAGES_READ:
+      FERRFLOW_PACKAGES_READ:
         required: false
 
 permissions:
@@ -126,7 +126,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
       - name: Typecheck
         if: inputs.enable-typecheck
@@ -170,7 +170,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
       - name: knip
         if: inputs.enable-knip


### PR DESCRIPTION
The org-wide secret used to read `@ferrlabs/*` GitHub Packages is named `FERRFLOW_PACKAGES_READ` (legacy from when the org was FerrFlow). Both `reusable-ci-node.yml` and `reusable-ci-astro.yml` declared and read `FERRLABS_PACKAGES_READ`, so even with `secrets: inherit` the lookup missed and pnpm fell back to `GITHUB_TOKEN` — which can't read packages from another repo and returns `ERR_PNPM_FETCH_403` (seen on FerrVault/FerrTrack/FerrGrowth/FerrFleet main CIs after the recent CI migration PRs).

Renamed in both reusable workflows.

Future cleanup: when the org rename FerrFlow → FerrLabs is fully complete (no more `FERRFLOW_*` references anywhere), rename the org secret to `FERRLABS_PACKAGES_READ` and flip these refs back. One source of truth then.