### PR TITLE
fix(reusable-ci): accept both FERRLABS_PACKAGES_READ and FERRFLOW_PACKAGES_READ

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -68,6 +68,11 @@ on:
         type: string
         default: '0.14.x'
     secrets:
+      # GitHub Packages read token. Either name works — `FERRLABS_PACKAGES_READ`
+      # is the eventual canonical (post-rename), `FERRFLOW_PACKAGES_READ` is the
+      # legacy from when the org was FerrFlow. Consumers can declare either.
+      FERRLABS_PACKAGES_READ:
+        required: false
       FERRFLOW_PACKAGES_READ:
         required: false
       LHCI_GITHUB_APP_TOKEN:
@@ -97,7 +102,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: pnpm install ${{ inputs.install-args }}
       - name: Astro check
         if: inputs.enable-astro-check
@@ -137,7 +142,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: pnpm install ${{ inputs.install-args }}
       - name: Check i18n parity
         run: pnpm run ${{ inputs.i18n-script }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -98,6 +98,11 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
+      # GitHub Packages read token. Either name works — `FERRLABS_PACKAGES_READ`
+      # is the eventual canonical (post-rename), `FERRFLOW_PACKAGES_READ` is the
+      # legacy from when the org was FerrFlow. Consumers can declare either.
+      FERRLABS_PACKAGES_READ:
+        required: false
       FERRFLOW_PACKAGES_READ:
         required: false
 
@@ -126,7 +131,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
       - name: Typecheck
         if: inputs.enable-typecheck
@@ -170,7 +175,7 @@ jobs:
           scope: ${{ inputs.registry-scope }}
       - name: Install dependencies
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.FERRLABS_PACKAGES_READ || secrets.FERRFLOW_PACKAGES_READ || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package-manager }} install ${{ inputs.install-args }}
       - name: knip
         if: inputs.enable-knip


### PR DESCRIPTION
Belt-and-braces — declare both secret names and fall back through them, so the reusable workflow works regardless of which name the org / consumer repo has configured.

Order of preference:
1. `FERRLABS_PACKAGES_READ` — eventual canonical name (post org rename)
2. `FERRFLOW_PACKAGES_READ` — current legacy name (in use today)
3. `secrets.GITHUB_TOKEN` — last resort, only works for same-repo packages

Applies to both `reusable-ci-node.yml` and `reusable-ci-astro.yml`.

Once the org-secret rename completes (FerrFlow → FerrLabs across the board), the `FERRFLOW_*` line can be dropped.