### PR TITLE
feat(renovate): self-hosted runner workflow + tightened preset

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,44 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options: ["debug", "info", "warn", "error"]
+      repoFilter:
+        description: 'Repo filter (e.g. "FerrLabs/UI" to scan a single repo)'
+        required: false
+        default: ""
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Run Renovate
+    runs-on: ferrlabs-k8s
+    steps:
+      - name: Checkout config
+        uses: actions/checkout@v6
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.3.1
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          configurationFile: default.json
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_AUTODISCOVER: "true"
+          RENOVATE_AUTODISCOVER_FILTER: ${{ inputs.repoFilter || 'FerrLabs/*' }}
+          RENOVATE_PLATFORM: "github"
+          RENOVATE_REPOSITORY_CACHE: "enabled"
+          RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@ferrlabs.com>"

--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 4,
   "labels": ["dependencies"],
+  "platformAutomerge": false,
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
@@ -23,13 +24,25 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "FerrLabs own packages — trust them, merge without delay",
+      "description": "FerrLabs npm packages — trust them, scan often, merge without delay",
       "matchPackagePatterns": ["^@ferrlabs/"],
+      "schedule": ["* * * * *"],
       "minimumReleaseAge": "0",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
-      "groupName": "FerrLabs packages"
+      "groupName": "FerrLabs npm packages"
+    },
+    {
+      "description": "FerrLabs Kit crates pinned via git rev — scan often, merge without delay",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["FerrLabs/Kit"],
+      "schedule": ["* * * * *"],
+      "minimumReleaseAge": "0",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrLabs Kit"
     },
     {
       "description": "High merge confidence — auto-merge non-major",
@@ -40,7 +53,7 @@
       "automergeStrategy": "squash"
     },
     {
-      "description": "Cargo patch + minor — auto-merge (no merge confidence data on crates.io)",
+      "description": "Cargo patch + minor (third-party) — auto-merge (no merge confidence on crates.io)",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -48,16 +61,18 @@
       "automergeStrategy": "squash"
     },
     {
-      "description": "GitHub Actions — grouped + auto-merge",
+      "description": "GitHub Actions — grouped + auto-merge, weekly",
       "matchManagers": ["github-actions"],
+      "schedule": ["before 6am on monday"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Dockerfile base images — grouped + auto-merge",
+      "description": "Dockerfile base images — grouped + auto-merge, weekly",
       "matchManagers": ["dockerfile"],
+      "schedule": ["before 6am on monday"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
@@ -67,6 +82,20 @@
       "description": "Major updates — always manual",
       "matchUpdateTypes": ["major"],
       "automerge": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "FerrLabs Kit crates pinned via git rev = ... in Cargo.toml",
+      "fileMatch": ["(^|/)Cargo\\.toml$"],
+      "matchStrings": [
+        "ferrlabs-[a-z\\-]+\\s*=\\s*\\{\\s*git\\s*=\\s*\"https://github.com/FerrLabs/Kit\\.git\"\\s*,\\s*rev\\s*=\\s*\"(?<currentDigest>[a-f0-9]+)\"\\s*\\}"
+      ],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "FerrLabs/Kit",
+      "packageNameTemplate": "FerrLabs/Kit",
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Sets up Renovate on the \`ferrlabs-k8s\` runner with a centralized config in this repo, replacing the bespoke dispatch chain (UI \`notify-consumers\` + per-consumer \`bump-ferrlabs.yml\` / \`bump-kit.yml\`) **and** the Dependabot setup that was just rolled out (PRs #251 #471 #159 #164 #141 #128 #125, all merged).

## Changes

- \`.github/workflows/renovate.yml\` — cron every 15 min on \`ferrlabs-k8s\`, autodiscovers \`FerrLabs/*\`. Manual \`workflow_dispatch\` with \`repoFilter\` input for ad-hoc one-off scans.
- \`default.json\`:
  - \`platformAutomerge: false\` — Renovate manages merges itself, no dependency on the per-repo "Allow auto-merge" setting.
  - \`@ferrlabs/*\` npm rule: \`schedule: ["* * * * *"]\`, \`minimumReleaseAge: 0\`, \`automerge: true\` — gives quasi-instant cascade after UI publishes.
  - New rule for \`ferrlabs-*\` Kit crates (pinned via \`git rev = ...\`): same schedule + automerge. Replaces \`bump-kit.yml\` + Kit \`notify-consumers\`.
  - \`customManagers.regex\`: picks up \`ferrlabs-* = { git = "...Kit.git", rev = "<sha>" }\` entries in \`Cargo.toml\` and bumps the \`<sha>\` via the \`github-tags\` datasource.
  - GitHub Actions + Dockerfile bumps moved to Monday-morning batch.

## Required setup before merge

- \`RENOVATE_TOKEN\` org-secret: PAT with **\`repo\` + \`workflow\`** scopes. Workflow scope is needed so Renovate can update \`.github/workflows/*.yml\` files.

## Follow-up PRs (one per consumer)

After this lands:
- 6 consumer repos: add a thin \`renovate.json\` extending \`github>FerrLabs/.github\`, delete \`dependabot.yml\` + \`dependabot-auto-merge.yml\` + \`bump-kit.yml\`.
- \`Kit\`: drop the \`notify-consumers\` job from \`release.yml\`.

## Test plan
- [ ] Set \`RENOVATE_TOKEN\` secret on the org
- [ ] Run via \`workflow_dispatch\` with \`repoFilter: FerrLabs/UI\` first to verify the runner image has node + git
- [ ] Then run autodiscover on \`FerrLabs/*\` and check the dependency dashboard issue gets created on each consumer