### PR TITLE
chore(renovate): explicit minimumReleaseAge per rule + tighten to 3 days for actions/docker

### DIFF
--- a/default.json
+++ b/default.json
@@ -45,34 +45,41 @@
       "groupName": "FerrLabs Kit"
     },
     {
-      "description": "High merge confidence — auto-merge non-major",
+      "description": "Third-party npm — wait 1 day after release before opening PR (supply-chain quarantine), auto-merge only if mergeConfidence is high/very-high",
+      "matchManagers": ["npm"],
+      "excludePackagePatterns": ["^@ferrlabs/"],
       "matchUpdateTypes": ["patch", "minor"],
       "matchMergeConfidence": ["high", "very high"],
+      "minimumReleaseAge": "1 day",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
-      "description": "Cargo patch + minor (third-party) — auto-merge (no merge confidence on crates.io)",
+      "description": "Third-party Cargo — wait 1 day after release before opening PR (no merge confidence on crates.io, so this is the main safety gate)",
       "matchManagers": ["cargo"],
+      "excludeDepNames": ["/^ferrlabs-/"],
       "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "1 day",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
-      "description": "GitHub Actions — grouped + auto-merge, weekly",
+      "description": "GitHub Actions — wait 3 days after release (action authors often re-tag), grouped + auto-merge weekly",
       "matchManagers": ["github-actions"],
       "schedule": ["before 6am on monday"],
+      "minimumReleaseAge": "3 days",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Dockerfile base images — grouped + auto-merge, weekly",
+      "description": "Dockerfile base images — wait 3 days, grouped + auto-merge weekly",
       "matchManagers": ["dockerfile"],
       "schedule": ["before 6am on monday"],
+      "minimumReleaseAge": "3 days",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",


### PR DESCRIPTION
## Summary
- Makes the supply-chain quarantine intent explicit on each non-ferrlabs rule (was inherited from the top-level default, easy to break silently).
- Tightens `minimumReleaseAge` to 3 days for GitHub Actions and Dockerfile base images (re-tag risk: see [tj-actions/changed-files March 2025 incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).
- Third-party npm + Cargo stay at 1 day (project minimum).
- FerrLabs own packages (npm + Kit) stay at 0 — we publish, we trust.
- Vulnerability alerts stay at 0 — CVE patches must land faster than the quarantine.