### PR TITLE
fix(renovate): run on ubuntu-latest, not self-hosted k8s

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   renovate:
     name: Run Renovate
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout config
         uses: actions/checkout@v6


### PR DESCRIPTION
Public repo + self-hosted runner = security risk (fork PRs can run code on the k8s host). GitHub-hosted ubuntu-latest is free + unlimited on public repos. Renovate doesn't need anything special — Node + git + network suffices. Drains the stuck queued runs as a bonus.