### PR TITLE
chore(renovate): onboarding PRs now extend the FerrLabs preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,12 @@
   "prHourlyLimit": 4,
   "labels": ["dependencies"],
   "platformAutomerge": false,
+  "onboardingConfig": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>FerrLabs/.github"]
+  },
+  "onboardingConfigFileName": "renovate.json",
+  "onboardingPrTitle": "chore: configure Renovate (extend FerrLabs preset)",
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],


### PR DESCRIPTION
Setting `onboardingConfig` so future onboarding PRs (Benchmarks, Fixtures, MCP, ferrflow-operator, FerrGames-Cloud, Infra, …) ship a `renovate.json` with `extends: ["github>FerrLabs/.github"]` instead of an empty schema-only stub. Matches the 6 cloud consumers' style and makes the rule source obvious to anyone reading the repo.