### PR TITLE
chore(renovate): self-extend the preset for consistency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>FerrLabs/.github"]
 }


### PR DESCRIPTION
Bring the renovate.json in this repo in line with the 6 cloud consumers — explicit `extends: ["github>FerrLabs/.github"]` instead of the schema-only stub from PR #34's onboarding.