### PR TITLE
fix(renovate): GHCR npm auth + git-refs datasource for FerrLabs/Kit

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,3 +42,31 @@ jobs:
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
           RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@ferrlabs.com>"
+          # Auth for GHCR npm registry (where @ferrlabs/* live).
+          # Without this, lookups for @ferrlabs/ui, @ferrlabs/ui-astro,
+          # @ferrlabs/ui-foundation fail with `no-result` because Renovate
+          # tries npmjs.org by default. The packageRule in default.json
+          # overrides registryUrls to npm.pkg.github.com; this token lets
+          # us actually authenticate against it.
+          # Same token is used by the github-actions hostRule for cross-repo
+          # actions (octokit calls when resolving release notes for things
+          # like FerrLabs/UI tags) and by the git-refs datasource fetching
+          # FerrLabs/Kit refs/heads/main.
+          RENOVATE_HOST_RULES: |
+            [
+              {
+                "matchHost": "npm.pkg.github.com",
+                "hostType": "npm",
+                "token": "${{ secrets.RENOVATE_TOKEN }}"
+              },
+              {
+                "matchHost": "github.com",
+                "hostType": "github-tags",
+                "token": "${{ secrets.RENOVATE_TOKEN }}"
+              },
+              {
+                "matchHost": "github.com",
+                "hostType": "git-refs",
+                "token": "${{ secrets.RENOVATE_TOKEN }}"
+              }
+            ]

--- a/default.json
+++ b/default.json
@@ -30,8 +30,9 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "FerrLabs npm packages — trust them, scan often, merge without delay",
+      "description": "FerrLabs npm packages — trust them, scan often, merge without delay. Override registry to GHCR (npm.pkg.github.com) since these packages aren't on npmjs.org. Auth comes from RENOVATE_HOST_RULES env in the runner workflow.",
       "matchPackagePatterns": ["^@ferrlabs/"],
+      "registryUrls": ["https://npm.pkg.github.com"],
       "schedule": ["* * * * *"],
       "minimumReleaseAge": "0",
       "automerge": true,
@@ -100,15 +101,15 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "FerrLabs Kit crates pinned via git rev = ... in Cargo.toml",
+      "description": "FerrLabs Kit crates pinned via git rev = ... in Cargo.toml. Tracks the HEAD of `main` via the git-refs datasource — Kit publishes per-crate tags (ferrlabs-types-v0.4.0 etc.), not a single repo-wide semver tag, so github-tags doesn't fit. git-refs returns the SHA of refs/heads/main and Renovate bumps the rev= to it.",
       "fileMatch": ["(^|/)Cargo\\.toml$"],
       "matchStrings": [
         "ferrlabs-[a-z\\-]+\\s*=\\s*\\{\\s*git\\s*=\\s*\"https://github.com/FerrLabs/Kit\\.git\"\\s*,\\s*rev\\s*=\\s*\"(?<currentDigest>[a-f0-9]+)\"\\s*\\}"
       ],
       "currentValueTemplate": "main",
       "depNameTemplate": "FerrLabs/Kit",
-      "packageNameTemplate": "FerrLabs/Kit",
-      "datasourceTemplate": "github-tags"
+      "packageNameTemplate": "https://github.com/FerrLabs/Kit",
+      "datasourceTemplate": "git-refs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

First real Renovate run flagged three lookup failures:

\`\`\`
Failed to look up npm package @ferrlabs/ui: no-result
Failed to look up npm package @ferrlabs/ui-astro: no-result
Could not determine new digest for update (github-tags package FerrLabs/Kit)
\`\`\`

Two distinct root causes, both fixed here.

## 1. \`@ferrlabs/*\` npm packages live on GHCR, not npmjs.org

Renovate queries \`registry.npmjs.org\` by default. Fix:
- New \`packageRule\` overrides \`registryUrls\` to \`https://npm.pkg.github.com\` for \`@ferrlabs/*\`.
- \`RENOVATE_HOST_RULES\` env in the workflow injects \`RENOVATE_TOKEN\` for \`npm.pkg.github.com\` auth (same token used for GitHub API).

## 2. \`FerrLabs/Kit\` Cargo bumps used the wrong datasource

The customManager used \`github-tags\`, but Kit publishes **per-crate** tags (\`ferrlabs-types-v0.4.0\`, \`ferrlabs-telemetry-v0.3.0\`, …) — not a single repo-wide semver — so Renovate couldn't pick one.

Fix: switch to \`git-refs\` datasource with \`packageName\` as the full git URL. Renovate now follows \`refs/heads/main\` HEAD and bumps the \`rev=\` SHA in \`Cargo.toml\` accordingly.

## Bonus

Added \`github-tags\` + \`git-refs\` hostRules entries pointing at the same token, so cross-repo release-note fetching and ref resolution during a full org scan use authenticated requests (avoids hitting the unauth rate limit).