### PR TITLE
feat(renovate): run under a dedicated GitHub App identity

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,5 +1,24 @@
 name: Renovate
 
+# Runs Renovate self-hosted under a dedicated GitHub App identity
+# (`ferrlabs-renovate[bot]`) installed in the FerrLabs org. Every commit,
+# PR, branch, and issue Renovate creates is attributed to the bot — not
+# to whichever human happens to own the PAT.
+#
+# Required org-level secrets (Settings → Secrets and variables → Actions):
+#   - RENOVATE_APP_ID            : GitHub App numeric ID (from app's settings page)
+#   - RENOVATE_APP_PRIVATE_KEY   : PEM-encoded private key (full content incl. BEGIN/END lines)
+#
+# To create the App: see the README in this repo or
+# https://github.com/organizations/FerrLabs/settings/apps/new
+#
+# Required App permissions:
+#   Repository → Contents (R/W), Issues (R/W), Pull requests (R/W),
+#                Workflows (R/W), Statuses (R/W), Metadata (R),
+#                Members (R), Dependabot alerts (R)
+#   Organization → Members (R)
+# Install on: All repositories under FerrLabs.
+
 on:
   schedule:
     - cron: "*/15 * * * *"
@@ -27,13 +46,24 @@ jobs:
     name: Run Renovate
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived (1h) installation token from the GitHub App.
+      # Replaces the long-lived PAT we used previously — commits and PRs
+      # are now attributed to `ferrlabs-renovate[bot]` instead of a human.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          owner: FerrLabs
+
       - name: Checkout config
         uses: actions/checkout@v6
 
       - name: Run Renovate
         uses: renovatebot/github-action@v40.3.1
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           configurationFile: default.json
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
@@ -41,7 +71,13 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: ${{ inputs.repoFilter || 'FerrLabs/*' }}
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
-          RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@ferrlabs.com>"
+          # Identity of every commit / PR / issue Renovate makes. Format
+          # `<numeric-app-id>+<bot-slug>[bot]@users.noreply.github.com`
+          # is the GitHub-canonical bot author. The numeric prefix is
+          # what GitHub needs to attribute correctly in the timeline UI;
+          # the bot-id env var is set from the token-mint step's output.
+          RENOVATE_GIT_AUTHOR: "${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.app-token.outputs.bot-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          RENOVATE_USERNAME: "${{ steps.app-token.outputs.app-slug }}[bot]"
           # Auth for GHCR npm registry (where @ferrlabs/* live).
           # Without this, lookups for @ferrlabs/ui, @ferrlabs/ui-astro,
           # @ferrlabs/ui-foundation fail with `no-result` because Renovate
@@ -57,16 +93,16 @@ jobs:
               {
                 "matchHost": "npm.pkg.github.com",
                 "hostType": "npm",
-                "token": "${{ secrets.RENOVATE_TOKEN }}"
+                "token": "${{ steps.app-token.outputs.token }}"
               },
               {
                 "matchHost": "github.com",
                 "hostType": "github-tags",
-                "token": "${{ secrets.RENOVATE_TOKEN }}"
+                "token": "${{ steps.app-token.outputs.token }}"
               },
               {
                 "matchHost": "github.com",
                 "hostType": "git-refs",
-                "token": "${{ secrets.RENOVATE_TOKEN }}"
+                "token": "${{ steps.app-token.outputs.token }}"
               }
             ]


### PR DESCRIPTION
## Summary
Renovate now mints short-lived (1h) installation tokens from a dedicated **GitHub App** in the FerrLabs org instead of using a long-lived PAT scoped to a human account. Every commit, PR, branch, and issue Renovate creates is attributed to \`ferrlabs-renovate[bot]\` instead of \`BryanFRD\`.

## Required setup (one-off, in GitHub UI)

⚠️ **Don't merge until these 3 secrets are in place** — otherwise the next scheduled run fails. Order:

### 1. Create the GitHub App
Go to https://github.com/organizations/FerrLabs/settings/apps/new and configure:

- **GitHub App name**: \`ferrlabs-renovate\`
- **Homepage URL**: \`https://github.com/FerrLabs/.github\`
- **Webhook**: ☐ Active (uncheck — Renovate doesn't use webhooks in self-hosted mode)
- **Repository permissions**:
  - Contents: **Read and write**
  - Issues: **Read and write**
  - Pull requests: **Read and write**
  - Workflows: **Read and write**
  - Statuses: **Read and write**
  - Metadata: **Read-only** (mandatory)
  - Members: **Read-only**
  - Dependabot alerts: **Read-only**
- **Organization permissions**:
  - Members: **Read-only**
- **Where can this GitHub App be installed?**: \`Only on this account\`

Save → you land on the App's settings page.

### 2. Generate a private key
Same page, scroll to "Private keys" → "Generate a private key" → downloads a \`.pem\` file. Open it, copy the **entire content** including \`-----BEGIN PRIVATE KEY-----\` and \`-----END PRIVATE KEY-----\`.

Note the **App ID** displayed at the top of the settings page (e.g. \`1234567\`).

### 3. Install the App on the org
Same page, sidebar → "Install App" → click "Install" next to \`FerrLabs\` → choose **All repositories**.

### 4. Add the secrets
Go to https://github.com/organizations/FerrLabs/settings/secrets/actions/new (org-level Action secrets):

- Name: \`RENOVATE_APP_ID\` — Value: the numeric App ID from step 2 (e.g. \`1234567\`)
- Name: \`RENOVATE_APP_PRIVATE_KEY\` — Value: the full PEM content from step 2

Repository access for both: **All repositories**.

### 5. Merge this PR
The next scheduled Renovate run (or a manual \`gh workflow run renovate.yml -R FerrLabs/.github\`) picks up the App identity automatically.

### 6. Cleanup
Once you confirm the App-based run works, remove the \`RENOVATE_TOKEN\` org secret and revoke the underlying PAT — neither is used anymore.

## Trade-offs

- ✅ Tokens are 1-hour TTL, auto-rotated by GitHub — leaks bounded
- ✅ Permissions are minimal (no \`repo\` mega-scope, no admin, no secrets read)
- ✅ No human seat consumed
- ✅ \`ferrlabs-renovate[bot]\` makes audit logs self-documenting
- ⚠️ Slightly more setup vs. a PAT (one-off ~5 min)