### PR TITLE
chore(workflows): migrate ubuntu-latest to ferrlabs-k8s self-hosted runner

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ permissions: {}
 jobs:
   renovate:
     name: Run Renovate
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       # Mint a short-lived (1h) installation token from the GitHub App.
       # Replaces the long-lived PAT we used previously — commits and PRs

--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -124,7 +124,7 @@ jobs:
   i18n:
     name: i18n parity
     if: inputs.enable-i18n
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -152,7 +152,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -156,7 +156,7 @@ jobs:
   quality:
     name: Quality (knip, madge, audit)
     if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   hadolint:
     name: hadolint
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: hadolint/hadolint-action@v3.1.0
@@ -101,7 +101,7 @@ jobs:
     name: Trivy (CVE scan)
     needs: build
     if: inputs.push
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: aquasecurity/trivy-action@0.35.0
         with:
@@ -122,7 +122,7 @@ jobs:
     name: cosign (sign + attest)
     needs: [build, trivy]
     if: inputs.push
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: sigstore/cosign-installer@v3
       - name: Login to GHCR
@@ -148,7 +148,7 @@ jobs:
     name: SBOM (Syft → CycloneDX)
     needs: build
     if: inputs.push
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -104,7 +104,7 @@ jobs:
   upload:
     name: Attest + upload assets
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
@@ -128,7 +128,7 @@ jobs:
     name: Publish crates.io
     needs: upload
     if: inputs.crate-publish
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
         with:
@@ -39,9 +39,11 @@ jobs:
       - name: Install gitleaks
         run: |
           VERSION=8.21.2
+          mkdir -p "$HOME/.local/bin"
           curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
-          gitleaks version
+            | tar -xz -C "$HOME/.local/bin" gitleaks
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/gitleaks" version
       - name: Run gitleaks
         env:
           GITLEAKS_CONFIG: ${{ inputs.gitleaks-config }}
@@ -70,7 +72,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - name: Detect Go module
@@ -85,10 +87,12 @@ jobs:
         if: steps.detect.outputs.has_go == 'false'
         run: |
           VERSION=2.0.2
+          mkdir -p "$HOME/.local/bin"
           curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${VERSION}/osv-scanner_linux_amd64" \
-            -o /usr/local/bin/osv-scanner
-          chmod +x /usr/local/bin/osv-scanner
-          osv-scanner --version
+            -o "$HOME/.local/bin/osv-scanner"
+          chmod +x "$HOME/.local/bin/osv-scanner"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/osv-scanner" --version
       - name: Skip osv-scanner on Go repos
         if: steps.detect.outputs.has_go == 'true'
         run: |
@@ -118,7 +122,7 @@ jobs:
 
   trufflehog:
     name: trufflehog (secrets, deep history)
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
@@ -126,9 +130,11 @@ jobs:
           fetch-depth: 0
       - name: Install trufflehog
         run: |
+          mkdir -p "$HOME/.local/bin"
           curl -fsSL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
-            | sh -s -- -b /usr/local/bin
-          trufflehog --version
+            | sh -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/trufflehog" --version
       - name: Run trufflehog (filesystem + git history)
         run: |
           set +e

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -29,7 +29,7 @@ Hosting the reusables in the **public** `.github` repo (rather than the private 
 
 ## Conventions
 
-- Default runner: `ubuntu-latest`. Heavier jobs (Node install, Astro build, Docker build) target the self-hosted `ferrlabs-k8s` cluster.
+- Default runner: `ferrlabs-k8s` (self-hosted Kubernetes cluster). All jobs target it to avoid GitHub Actions billing on private repos.
 - Pinned major versions for trusted official actions (`actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, etc.).
 - Coverage is uploaded to Codecov when `CODECOV_TOKEN` is set; failures are non-blocking.
 - All security templates upload SARIF to the GitHub code-scanning UI.

--- a/workflow-templates/ci-astro.yml
+++ b/workflow-templates/ci-astro.yml
@@ -45,7 +45,7 @@ jobs:
 
   i18n:
     name: i18n parity
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
@@ -69,7 +69,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/workflow-templates/ci-go.yml
+++ b/workflow-templates/ci-go.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     name: Lint
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -38,7 +38,7 @@ jobs:
   test:
     name: Test
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -56,7 +56,7 @@ jobs:
   security:
     name: Security
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -72,7 +72,7 @@ jobs:
     name: Build
     needs: [lint, test]
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/workflow-templates/ci-node.yml
+++ b/workflow-templates/ci-node.yml
@@ -44,7 +44,7 @@ jobs:
 
   quality:
     name: Quality (knip, madge, audit)
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/workflow-templates/ci-rust.yml
+++ b/workflow-templates/ci-rust.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Test
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -35,7 +35,7 @@ jobs:
   security:
     name: Cargo Security
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -52,7 +52,7 @@ jobs:
 
   typos:
     name: Typos
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@master
@@ -60,7 +60,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     permissions:
       security-events: write
       packages: read

--- a/workflow-templates/pr-title.yml
+++ b/workflow-templates/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/workflow-templates/scorecard.yml
+++ b/workflow-templates/scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
Migrate every `runs-on: ubuntu-latest` in this repo to `runs-on: ferrlabs-k8s` (self-hosted Kubernetes runner) to stop burning GitHub Actions billing on private repos.

## Scope
- Reusable workflows: `reusable-ci-astro.yml`, `reusable-ci-node.yml`, `reusable-docker-build.yml`, `reusable-release-rust.yml`, `reusable-security-scan.yml`
- Workflow templates: `ci-astro.yml`, `ci-go.yml`, `ci-node.yml`, `ci-rust.yml`, `codeql.yml`, `pr-title.yml`, `scorecard.yml`
- Repo-local: `renovate.yml`
- Doc: `workflow-templates/README.md` updated to reflect the new default runner

## Skipped intentionally
- Lines using `${{ inputs.runner }}` (parameterized — consumers pass `ferrlabs-k8s`)
- Matrix entries `os: ubuntu-latest` and `if: matrix.os == 'ubuntu-latest'` in `reusable-release-rust.yml` — those drive cross-compilation targets, not runner selection
- `default: 'ubuntu-latest'` in `workflow_call` inputs of `reusable-ci-go.yml` / `reusable-ci-rust.yml` — defaults; consumers override

## Self-hosted runner caveat — binary installs
The runner cannot write to `/usr/local/bin` (no sudo). In `reusable-security-scan.yml`, swapped `curl | tar -xz -C /usr/local/bin` for `$HOME/.local/bin` + `$GITHUB_PATH`. Applies to `gitleaks`, `osv-scanner`, `trufflehog`. Paths are double-quoted to be safe with future workspace paths containing spaces.

After merge, re-run failed CI on existing PRs via `gh run rerun --failed`.