### PR TITLE
fix(workflows): install security tools to RUNNER_TEMP (HOME not writable on self-hosted)

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Install gitleaks
         run: |
           VERSION=8.21.2
-          mkdir -p "$HOME/.local/bin"
+          mkdir -p "$RUNNER_TEMP/bin"
           curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C "$HOME/.local/bin" gitleaks
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/gitleaks" version
+            | tar -xz -C "$RUNNER_TEMP/bin" gitleaks
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/gitleaks" version
       - name: Run gitleaks
         env:
           GITLEAKS_CONFIG: ${{ inputs.gitleaks-config }}
@@ -87,12 +87,12 @@ jobs:
         if: steps.detect.outputs.has_go == 'false'
         run: |
           VERSION=2.0.2
-          mkdir -p "$HOME/.local/bin"
+          mkdir -p "$RUNNER_TEMP/bin"
           curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${VERSION}/osv-scanner_linux_amd64" \
-            -o "$HOME/.local/bin/osv-scanner"
-          chmod +x "$HOME/.local/bin/osv-scanner"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/osv-scanner" --version
+            -o "$RUNNER_TEMP/bin/osv-scanner"
+          chmod +x "$RUNNER_TEMP/bin/osv-scanner"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/osv-scanner" --version
       - name: Skip osv-scanner on Go repos
         if: steps.detect.outputs.has_go == 'true'
         run: |
@@ -130,11 +130,11 @@ jobs:
           fetch-depth: 0
       - name: Install trufflehog
         run: |
-          mkdir -p "$HOME/.local/bin"
+          mkdir -p "$RUNNER_TEMP/bin"
           curl -fsSL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
-            | sh -s -- -b "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/trufflehog" --version
+            | sh -s -- -b "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/trufflehog" --version
       - name: Run trufflehog (filesystem + git history)
         run: |
           set +e


### PR DESCRIPTION
After migrating gitleaks/osv-scanner/trufflehog to ferrlabs-k8s, the install steps fail with:

\`\`\`
mkdir: cannot create directory '/home/runner/.local/bin': Permission denied
\`\`\`

The runner user on the self-hosted Kubernetes runner does not own \`/home/runner/.local\`. Switch the install path to \`$RUNNER_TEMP/bin\` which is guaranteed writable per the GitHub Actions runner contract and ephemeral per-job (no leakage between runs).

After merge, re-run failed CI on existing PRs via \`gh run rerun --failed\`.