### PR TITLE
chore(ci): default reusable runners to ubuntu-latest for public consumers

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -10,7 +10,7 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         type: string
-        default: 'ferrlabs-k8s'
+        default: 'ubuntu-latest'
       node-version:
         type: string
         default: '24'

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -10,7 +10,7 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         type: string
-        default: 'ferrlabs-k8s'
+        default: 'ubuntu-latest'
       node-version:
         description: 'Node.js version'
         type: string

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -41,6 +41,11 @@ on:
         type: boolean
         required: false
         default: true
+      runner:
+        description: 'GitHub Actions runner label for the build job (the heavy one). Private consumers pass `ferrlabs-k8s`; public consumers leave the default.'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
     outputs:
       digest:
         description: 'Image digest (sha256:...)'
@@ -67,7 +72,7 @@ jobs:
   build:
     name: Build & push
     needs: hadolint
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -29,7 +29,7 @@ Hosting the reusables in the **public** `.github` repo (rather than the private 
 
 ## Conventions
 
-- Default runner: `ferrlabs-k8s` (self-hosted Kubernetes cluster). All jobs target it to avoid GitHub Actions billing on private repos.
+- Default runner: `ubuntu-latest` (GitHub-hosted, free on public repos). Private repos override by passing `runner: ferrlabs-k8s` to the reusable workflows to use the self-hosted Kubernetes cluster and avoid GitHub Actions billing.
 - Pinned major versions for trusted official actions (`actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, etc.).
 - Coverage is uploaded to Codecov when `CODECOV_TOKEN` is set; failures are non-blocking.
 - All security templates upload SARIF to the GitHub code-scanning UI.

--- a/workflow-templates/ci-astro.yml
+++ b/workflow-templates/ci-astro.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     name: Build & Check
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/workflow-templates/ci-node.yml
+++ b/workflow-templates/ci-node.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   test:
     name: Test & Build
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   release:
     name: Run FerrFlow
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(release):')) ||
       github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Default the `runner` input on all reusable workflows to `ubuntu-latest` so public OSS consumers (FerrFlow, Benchmarks, Fixtures, FerrVault operator) run on GitHub-hosted runners for free, while private consumers (Cloud APIs/sites, Kit, UI, MCP, Infra) keep passing `runner: ferrlabs-k8s` explicitly.

Why:
- Public repos get unlimited free minutes on GitHub-hosted runners
- Stop burning self-hosted capacity for OSS workloads
- No infra dependency for OSS contributors / community PRs
- Safer default: a new consumer that forgets to set `runner` lands on free hosted runners, not on the private cluster

## Reusables touched

| File | Change |
|---|---|
| `reusable-ci-astro.yml` | `runner` default `ferrlabs-k8s` → `ubuntu-latest` |
| `reusable-ci-node.yml` | `runner` default `ferrlabs-k8s` → `ubuntu-latest` |
| `reusable-docker-build.yml` | New `runner` input (default `ubuntu-latest`); `build` job switches `runs-on: ferrlabs-k8s` → `runs-on: ${{ inputs.runner }}` |

Already correct (no change needed):
- `reusable-ci-rust.yml` — already defaults to `ubuntu-latest`
- `reusable-ci-go.yml` — already defaults to `ubuntu-latest`
- `reusable-release-rust.yml` — uses the matrix-`os` pattern, no self-hosted reference
- `reusable-security-scan.yml` — hardcoded `ubuntu-latest` on every job (light, no need for parameterization)

## Workflow templates

`workflow-templates/{ci-astro,ci-node,release}.yml` switched from hardcoded `runs-on: ferrlabs-k8s` to `runs-on: ubuntu-latest`. New repos scaffolded from these templates land on free hosted runners by default; private repos can swap the line manually when they want the self-hosted cluster.

`README.md` clarified accordingly.

## Private consumer migration

Private repos (FerrLabs-Cloud, FerrFlow-Cloud, FerrVault-Cloud, FerrTrack-Cloud, FerrGrowth-Cloud, FerrFleet-Cloud, FerrGames-Cloud, Kit, UI, MCP, Infra) that consume these reusables need to keep passing `runner: ferrlabs-k8s` if they want the self-hosted cluster. A spot-check is in progress in a follow-up.