### PR TITLE
fix(workflows): default all reusable runners to ubuntu-latest for public consumers

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -124,7 +124,7 @@ jobs:
   i18n:
     name: i18n parity
     if: inputs.enable-i18n
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -152,7 +152,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -156,7 +156,7 @@ jobs:
   quality:
     name: Quality (knip, madge, audit)
     if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -61,7 +61,7 @@ permissions:
 jobs:
   hadolint:
     name: hadolint
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: hadolint/hadolint-action@v3.1.0
@@ -106,7 +106,7 @@ jobs:
     name: Trivy (CVE scan)
     needs: build
     if: inputs.push
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: aquasecurity/trivy-action@0.35.0
         with:
@@ -127,7 +127,7 @@ jobs:
     name: cosign (sign + attest)
     needs: [build, trivy]
     if: inputs.push
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: sigstore/cosign-installer@v3
       - name: Login to GHCR
@@ -153,7 +153,7 @@ jobs:
     name: SBOM (Syft → CycloneDX)
     needs: build
     if: inputs.push
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -22,6 +22,11 @@ on:
         type: string
         required: false
         default: ''
+      runner:
+        description: 'GitHub Actions runner label for the upload + publish jobs. Defaults to `ubuntu-latest` so public-repo consumers run on free GitHub-hosted runners.'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -104,7 +109,7 @@ jobs:
   upload:
     name: Attest + upload assets
     needs: build
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
@@ -128,7 +133,7 @@ jobs:
     name: Publish crates.io
     needs: upload
     if: inputs.crate-publish
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
         default: false
+      runner:
+        description: 'GitHub Actions runner label. Defaults to `ubuntu-latest` so public-repo consumers run on free GitHub-hosted runners. Private consumers can override with `ferrlabs-k8s` for the heavier self-hosted pool.'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
 
 permissions:
   contents: read
@@ -31,7 +36,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,7 +77,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
       - name: Detect Go module
@@ -122,7 +127,7 @@ jobs:
 
   trufflehog:
     name: trufflehog (secrets, deep history)
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

PR #44 added `runner: ubuntu-latest` defaults for the **main** job in each reusable workflow but left auxiliary jobs hardcoded to `ferrlabs-k8s`. Public-repo consumers (FerrFlow, FerrGames-Cloud, etc.) hit those auxiliary jobs and they queue indefinitely waiting for a self-hosted runner that doesn't exist.

Symptom from FerrFlow's `Secrets + CVE / gitleaks (secrets)` check:
```
Requested labels: ferrlabs-k8s
Waiting for a runner to pick up this job...
```

## Fix

All `runs-on: ferrlabs-k8s` swapped to `runs-on: ${{ inputs.runner }}` across:

- `reusable-security-scan.yml` — added `runner` input (was missing entirely), all 3 jobs (gitleaks, osv-scanner, trufflehog)
- `reusable-ci-astro.yml` — i18n + lighthouse jobs
- `reusable-ci-node.yml` — quality job
- `reusable-docker-build.yml` — hadolint, trivy, cosign, sbom jobs
- `reusable-release-rust.yml` — added `runner` input (was missing), upload + publish-crate + publish-docker jobs

Default in every case: `'ubuntu-latest'`. Private consumers can still pass `runner: 'ferrlabs-k8s'` to opt back into the self-hosted pool.

`renovate.yml` keeps `ferrlabs-k8s` because it's the org's own internal workflow, not a reusable consumed by public repos.

## Test plan

- [x] No `ferrlabs-k8s` left as `runs-on:` in reusable workflows (only as a default override mention in input descriptions)
- [ ] FerrFlow's next Security scan run picks up on `ubuntu-latest` instead of queuing forever
- [ ] Private consumers (none currently in use) can override via the existing `runner` input
