### PR TITLE
ci(security-scan): skip on private repos by default

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -28,6 +28,11 @@ on:
         type: string
         required: false
         default: 'ubuntu-latest'
+      run-on-private:
+        description: 'Set to `true` to run the scans on private repos too. Defaults to `false` because GitHub-hosted runners consume billed minutes on private repos and our security scans are best-effort hygiene, not blocking gates. Public repos always run (Actions are free for them).'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -37,6 +42,7 @@ jobs:
   gitleaks:
     name: gitleaks (secrets)
     runs-on: ${{ inputs.runner }}
+    if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -78,6 +84,7 @@ jobs:
   osv-scanner:
     name: osv-scanner (CVE)
     runs-on: ${{ inputs.runner }}
+    if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@v6
       - name: Detect Go module
@@ -128,7 +135,7 @@ jobs:
   trufflehog:
     name: trufflehog (secrets, deep history)
     runs-on: ${{ inputs.runner }}
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (!github.event.repository.private || inputs.run-on-private) }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Skip the reusable security scan (gitleaks / osv-scanner / trufflehog) on private repos by default — GitHub-hosted runners consume billed minutes there and the scans are best-effort hygiene, not blocking gates.
- Public repos always run (Actions are free for them).
- New input \`run-on-private: boolean\` (default \`false\`) lets callers opt in per-repo when they really want the scans on a private codebase and accept the billing.

## Why

We hit "The job was not started because recent account payments have failed or your spending limit needs to be increased" failures across every private-repo PR all session — gitleaks and osv-scanner blocked dozens of merges as red checks even though the scans had nothing to say. Skipping by default removes the noise without losing coverage on public repos (which is where the scans matter most for OSS supply-chain safety).

## Affected consumers

All repos with a `.github/workflows/security-scan.yml` that calls `FerrLabs/.github/.github/workflows/reusable-security-scan.yml`:

- FerrLabs/UI (public)
- FerrLabs/FerrFlow (public)
- FerrLabs/FerrFlow-Cloud (public)
- FerrLabs/FerrGrowth-Cloud (private)
- FerrLabs/FerrTrack-Cloud (private)
- FerrLabs/FerrVault-Cloud (private)
- FerrLabs/FerrFleet-Cloud (private)
- FerrLabs/FerrLabs-Cloud (mixed)
- FerrLabs/FerrGames-Cloud (private)
- FerrLabs/Kit, Infra, MCP, ferrflow-operator, Benchmarks, Fixtures, Status, Changelog (mixed)

After merge, every private repo automatically skips the 3 jobs unless it opts in by passing \`run-on-private: true\` to the reusable workflow.

## Test plan

- [x] YAML syntax valid (workflow editor)
- [ ] Public-repo run (UI, FerrFlow) still passes the jobs as before
- [ ] Private-repo run (FerrGrowth-Cloud, FerrTrack-Cloud) shows the 3 jobs as skipped (gray) instead of failed (red)