### PR TITLE
fix(renovate): catch missing Packages:read perm so internal libs actually update

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,9 +15,19 @@ name: Renovate
 # Required App permissions:
 #   Repository → Contents (R/W), Issues (R/W), Pull requests (R/W),
 #                Workflows (R/W), Statuses (R/W), Metadata (R),
-#                Members (R), Dependabot alerts (R)
+#                Members (R), Dependabot alerts (R),
+#                Packages (R)   ← REQUIRED for @ferrlabs/* lookups on GHCR npm
 #   Organization → Members (R)
 # Install on: All repositories under FerrLabs.
+#
+# About `Packages (R)`: @ferrlabs/ui, @ferrlabs/ui-astro,
+# @ferrlabs/ui-foundation are published to npm.pkg.github.com (GHCR) and
+# require auth to even READ. Without this permission Renovate gets 401 on
+# every lookup and silently emits no PRs for internal libs — third-party
+# crates / npm packages still work because they're public on crates.io /
+# npmjs.org. The first run after granting the permission opens the backlog
+# all at once. Verify via the bootstrap-check step below: it fails the
+# workflow with an actionable message if the token can't read the registry.
 
 on:
   schedule:
@@ -59,6 +69,29 @@ jobs:
 
       - name: Checkout config
         uses: actions/checkout@v6
+
+      - name: Verify token can read GHCR npm (catch missing Packages perm early)
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://npm.pkg.github.com/@ferrlabs%2Fui-astro")
+          if [ "${status}" = "200" ]; then
+            echo "ok — App token can read @ferrlabs/* on GHCR (${status})"
+          elif [ "${status}" = "401" ] || [ "${status}" = "403" ]; then
+            echo "::error::App token returned ${status} from npm.pkg.github.com." \
+                 "The 'ferrlabs-renovate' GitHub App is missing the 'Packages (read)'" \
+                 "repository permission. Grant it at" \
+                 "https://github.com/organizations/FerrLabs/settings/apps/ferrlabs-renovate/permissions" \
+                 "(Repository permissions → Packages → Read-only), then accept the new" \
+                 "permission request in the org settings. Without this, Renovate emits no" \
+                 "PRs for @ferrlabs/ui / @ferrlabs/ui-astro / @ferrlabs/ui-foundation."
+            exit 1
+          else
+            echo "::warning::Unexpected ${status} from npm.pkg.github.com — Renovate may still work but investigate."
+          fi
 
       - name: Run Renovate
         uses: renovatebot/github-action@v40.3.1


### PR DESCRIPTION
## Diagnosis

The `ferrlabs-renovate` GitHub App is missing the `Packages (read)` repository permission. That's why:

- 0 PRs ever opened for `@ferrlabs/ui`, `@ferrlabs/ui-astro`, `@ferrlabs/ui-foundation` across FerrLens-Cloud, FerrGrowth-Cloud, FerrTrack-Cloud, FerrVault-Cloud, FerrAgents.
- Third-party crates / npm packages (axum-test, vite, tower-http, storybook, toml) DO get PRs — they're public on crates.io / npmjs.org so no auth needed.
- `curl https://npm.pkg.github.com/@ferrlabs%2Fui-astro` returns `401 authentication token not provided` without a token, and the App's token is rejected because it has no `packages` scope.

The `RENOVATE_HOST_RULES` block sets the token correctly with `hostType: npm, matchHost: npm.pkg.github.com` — but a token without the `packages` permission is useless against a private GHCR registry.

## What this PR does

1. **Documents the requirement** in the workflow header comment so the next person setting up the App knows.
2. **Adds a bootstrap check** as a step before `Run Renovate`. It `curl`s the GHCR npm endpoint with the App token. On 401/403 the workflow fails with an actionable error message pointing at the exact org settings URL to fix the permission.

The check costs ~50ms per run and prevents another month of silent skipped internal-lib updates.

## What YOU still have to do manually

Open <https://github.com/organizations/FerrLabs/settings/apps/ferrlabs-renovate/permissions>, set **Repository permissions → Packages → Read-only**, save, then click "Review and accept" in the org settings to apply the new permission to the installation. Next scheduled Renovate run opens the backlog of `@ferrlabs/*` updates all at once.