### PR TITLE
fix(renovate): use ubuntu-latest instead of self-hosted ferrlabs-k8s

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -54,7 +54,12 @@ permissions: {}
 jobs:
   renovate:
     name: Run Renovate
-    runs-on: ferrlabs-k8s
+    # GitHub-hosted runner: free for this public repo, and the self-hosted
+    # `ferrlabs-k8s` group has allows_public_repositories=false (security
+    # default — don't expose the k8s cluster to public-repo workflows).
+    # Renovate only needs node + network reach to npm/crates.io/GHCR, no
+    # cluster-side resources.
+    runs-on: ubuntu-latest
     steps:
       # Mint a short-lived (1h) installation token from the GitHub App.
       # Replaces the long-lived PAT we used previously — commits and PRs


### PR DESCRIPTION
The \`.github\` repo is public, but every org-level runner group (incl. \`ferrlabs-k8s\` where the renovate runners live) has \`allows_public_repositories=false\` — the GitHub default that prevents public-repo workflows from reaching the k8s cluster.

Net effect today: every Renovate run since the group was tightened queues forever (run shows 0 jobs created, status stays \`pending\`), eventually cancelled by the next \`*/15 * * * *\` cron. No PRs ever get raised.

Renovate doesn't need cluster-side resources — just node + outbound HTTP to npm/crates.io/GHCR. \`ubuntu-latest\` is free for public repos and starts running within seconds.

Alternative considered: flipping \`allows_public_repositories=true\` on the runner group. Rejected — the default exists for a reason (any PR on a public repo can otherwise execute code on the cluster). Keep the security default, host Renovate on GitHub's free runners.