### PR TITLE
fix(security-scan): pin actions/checkout to v5

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Detect Go module
         id: detect
         run: |
@@ -137,7 +137,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (!github.event.repository.private || inputs.run-on-private) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install trufflehog


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to `v5` in `.github/workflows/reusable-security-scan.yml` (3 jobs: gitleaks, osv-scanner, trufflehog)
- `actions/checkout@v6` regression: drops `GITHUB_TOKEN` extraheader on deep fetch (`fetch-depth: 0`), causing `fatal: could not read Username for 'https://github.com'` on every scheduled scan

Closes #50

## Test plan
- [ ] PR CI green
- [ ] Verify next scheduled Security scan on `FerrLabs/Changelog` passes