### PR TITLE
chore(security-scan): bump codeql-action/upload-sarif to v4

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -118,7 +118,7 @@ jobs:
           exit-code: '1'
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -75,7 +75,7 @@ jobs:
           fi
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks
@@ -126,7 +126,7 @@ jobs:
           fi
       - name: Upload SARIF
         if: always() && hashFiles('osv-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner


### PR DESCRIPTION
## Summary
- Bump `github/codeql-action/upload-sarif` from `v3` to `v4` in `reusable-security-scan.yml` (gitleaks + osv-scanner upload steps) and `reusable-docker-build.yml` (trivy upload step)
- Clears the Node.js 20 deprecation annotation flagged on every Security scan run (v3 = Node 20, v4 = Node 24)

## Test plan
- [ ] PR CI green
- [ ] Subsequent Security scan dispatch produces no deprecation annotation