### PR TITLE
chore(ci): bump FerrLabs/FerrFlow action to v5

### DIFF
--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -14,7 +14,7 @@ GitHub-discovered workflow templates. They appear under **Actions → New workfl
 | [`scorecard`](scorecard.yml) | OpenSSF Scorecard supply-chain risk score | All public repos and key private repos. |
 | [`security-scan`](security-scan.yml) | Reusable: gitleaks (secrets) + osv-scanner (CVE) + trufflehog (deep history) | Every repo — call the shared workflow from `FerrLabs/.github`. |
 | [`pr-title`](pr-title.yml) | Conventional Commits validation on PR titles | Every repo (mandatory because we squash-merge). |
-| [`release`](release.yml) | Auto-release on push to main with `FerrLabs/FerrFlow@v4` | Repos that ship semver releases. |
+| [`release`](release.yml) | Auto-release on push to main with `FerrLabs/FerrFlow@v5` | Repos that ship semver releases. |
 | [`docker-publish`](docker-publish.yml) | Reusable: hadolint + multi-arch build + Trivy + cosign keyless + SBOM | Repos that publish a container image. |
 
 ## Reusable workflows

--- a/workflow-templates/release.properties.json
+++ b/workflow-templates/release.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "FerrLabs — Release with FerrFlow",
-  "description": "Automatic semver release on push to main using FerrLabs/FerrFlow@v4 (conventional commits, version bump, tag, GitHub release, changelog).",
+  "description": "Automatic semver release on push to main using FerrLabs/FerrFlow@v5 (conventional commits, version bump, tag, GitHub release, changelog).",
   "iconName": "ferrlabs",
   "categories": ["Deployment"],
   "filePatterns": [".*"]

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: FerrLabs/FerrFlow@v4
+      - uses: FerrLabs/FerrFlow@v5
         with:
           dry_run: ${{ inputs.dry_run || false }}
           bot: true


### PR DESCRIPTION
## Summary
- Bump `FerrLabs/FerrFlow@v4` → `@v5` in workflow files.

## Why
FerrFlow v5.0.0 released (2026-05-21). The only breaking change is internal — replaces URL token injection with the git credential helper protocol (#486 on FerrLabs/FerrFlow). The Action's YAML surface is unchanged; consumers just bump the major tag.

## Test plan
- [ ] CI green
- [ ] Next release run succeeds end-to-end