### PR TITLE
chore(template): release.yml — concurrency + checkout@v5

### DIFF
--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -14,6 +14,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Run FerrFlow
@@ -22,7 +26,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(release):')) ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
Two fixes for new repos scaffolded from this template:

- **Add `concurrency: release-${{ github.ref }}` with `cancel-in-progress: false`** — concurrent merges to main were causing FerrFlow release runs to race and the loser hit `E2006: tag already exists pointing at different commit`. Queuing release runs avoids this.
- **Pin `actions/checkout` from v6 to v5** — v6 drops `GITHUB_TOKEN` on deep fetches (`fetch-depth: 0`), same regression we patched in #51.

Existing repos that copied this template still need the same patch applied — see follow-up issue.