### PR TITLE
fix(renovate): trust FerrLabs internal packages, skip stability-days gate

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,26 +30,40 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "FerrLabs npm packages — trust them, scan often, merge without delay. Override registry to GHCR (npm.pkg.github.com) since these packages aren't on npmjs.org. Auth comes from RENOVATE_HOST_RULES env in the runner workflow.",
+      "description": "FerrLabs npm packages — trust them, scan often, merge without delay. Override registry to GHCR (npm.pkg.github.com) since these packages aren't on npmjs.org. Auth comes from RENOVATE_HOST_RULES env in the runner workflow. internalChecksFilter:none skips the stability-days gate inherited from the global default.",
       "matchPackagePatterns": ["^@ferrlabs/"],
       "registryUrls": ["https://npm.pkg.github.com"],
       "schedule": ["* * * * *"],
       "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "FerrLabs npm packages"
     },
     {
-      "description": "FerrLabs Kit crates pinned via git rev — scan often, merge without delay",
+      "description": "FerrLabs Kit crates pinned via git rev — scan often, merge without delay. Targets the depName the customManager below stamps (`FerrLabs/Kit`); `matchPackageNames` would compare against the packageName field (the full URL), so use matchDepNames here. internalChecksFilter:none skips stability-days.",
       "matchManagers": ["custom.regex"],
-      "matchPackageNames": ["FerrLabs/Kit"],
+      "matchDepNames": ["FerrLabs/Kit"],
       "schedule": ["* * * * *"],
       "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "FerrLabs Kit"
+    },
+    {
+      "description": "FerrLabs Cargo crates published from Kit (`ferrlabs-*`) — same trust as @ferrlabs/ npm packages. No wait, automerge.",
+      "matchManagers": ["cargo"],
+      "matchDepPatterns": ["^ferrlabs-"],
+      "schedule": ["* * * * *"],
+      "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrLabs Cargo crates"
     },
     {
       "description": "Third-party npm — wait 1 day after release before opening PR (supply-chain quarantine), auto-merge only if mergeConfidence is high/very-high",


### PR DESCRIPTION
## Problem
FerrLabs internal dependencies (Kit crates pinned via git rev, `@ferrlabs/*` npm packages) were getting the `renovate/stability-days` quarantine check applied to them, blocking auto-merge for 24h even though we control these packages and want immediate updates.

Concrete example: [FerrVault-Cloud#221](https://github.com/FerrLabs/FerrVault-Cloud/pull/221) — `chore(deps): update ferrlabs/kit digest to b0ec66e` — shows:
- `renovate/stability-days` pending
- "Automerge: Disabled by config"

## Root cause
The existing rule:

```json
{
  "matchManagers": ["custom.regex"],
  "matchPackageNames": ["FerrLabs/Kit"],
  ...
}
```

doesn't match because:
1. The customManager stamps `packageName: 'https://github.com/FerrLabs/Kit'` (the full URL) and `depName: 'FerrLabs/Kit'`.
2. `matchPackageNames` compares against the `packageName` field — full URL, not depName. The rule never fires.
3. Even when the rule does match, `mergeConfidence:all-badges` (extended at the top) still inserts the stability-days commit status from the Mend MC app, which is an *internal check* and isn't bypassed by `minimumReleaseAge: 0` alone — you need `internalChecksFilter: 'none'`.

## Fix
- Swap `matchPackageNames` → `matchDepNames` for the FerrLabs Kit rule.
- Add `internalChecksFilter: 'none'` to every FerrLabs-internal rule so the stability-days badge is dropped.
- Add a new rule for `ferrlabs-*` crates published from Kit via `matchManagers: ['cargo'] + matchDepPatterns: ['^ferrlabs-']` — covers the future case where Kit publishes to crates.io.

## Effect
- Next Renovate run on every consumer: PR opens, auto-merges immediately on green CI.
- Third-party deps still respect the 1-day quarantine via the existing rules below.

## Test plan
- [ ] Wait for next Renovate scheduled run (within minutes of merging)
- [ ] Verify a fresh FerrLabs/Kit digest PR has no `renovate/stability-days` check and auto-merges