### PR TITLE
fix(ci): separate coverage-flags so llvm-cov does not get duplicate --workspace

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -27,6 +27,10 @@ on:
         description: 'Flags appended to cargo invocations (clippy, test, build)'
         type: string
         default: '--all-features'
+      coverage-flags:
+        description: 'Flags for the coverage run (llvm-cov). Defaults to cargo-flags. Set separately when cargo-flags already carries --workspace, to avoid passing it twice to llvm-cov which rejects duplicates.'
+        type: string
+        default: ''
       clippy-args:
         description: 'Args after the `--` separator for clippy'
         type: string
@@ -280,7 +284,7 @@ jobs:
         if: inputs.coverage-tool == 'llvm-cov'
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo llvm-cov ${{ inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov ${{ inputs.coverage-flags || inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
       - name: Generate coverage (tarpaulin)
         if: inputs.coverage-tool == 'tarpaulin'
         env:


### PR DESCRIPTION
Kit's CI Coverage job fails on main with:
```
error: the argument '--workspace' was provided more than once
```
because `reusable-ci-rust.yml` runs `cargo llvm-cov ${{ inputs.cargo-flags }} --workspace ...` while Kit passes `cargo-flags: --workspace --all-features` (it needs `--workspace` for clippy/test). llvm-cov rejects the duplicate.

## Fix
New optional input `coverage-flags` (default `''`). The coverage step uses `coverage-flags || cargo-flags`. The hardcoded `--workspace` stays, so:
- Callers that don't set `coverage-flags` are unchanged (e.g. Finance, default `--all-features`, still covered workspace-wide).
- Callers whose `cargo-flags` already include `--workspace` (Kit) set `coverage-flags: --all-features` to avoid the duplicate.

Follow-up: Kit's `ci.yml` will add `coverage-flags: --all-features` once this lands (separate PR), which unblocks its coverage → SonarQube report.

YAML validated with PyYAML. Leaving OPEN for review.