### PR TITLE
fix: authenticate trivy and sbom jobs to GHCR for private images

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -111,6 +111,15 @@ jobs:
     if: inputs.push
     runs-on: ${{ inputs.runner }}
     steps:
+      # Trivy reads ~/.docker/config.json to pull the image; without this a
+      # private GHCR image fails with a 401/manifest-unknown.
+      - name: Login to GHCR
+        if: startsWith(inputs.image-name, 'ghcr.io/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ inputs.image-name }}:${{ inputs.tag }}
@@ -158,6 +167,15 @@ jobs:
     if: inputs.push
     runs-on: ${{ inputs.runner }}
     steps:
+      # Syft pulls the image via the Docker keychain (~/.docker/config.json);
+      # a private GHCR image needs this login or the scan fails to fetch it.
+      - name: Login to GHCR
+        if: startsWith(inputs.image-name, 'ghcr.io/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: anchore/sbom-action@v0
         with:
           image: ${{ inputs.image-name }}@${{ needs.build.outputs.digest }}


### PR DESCRIPTION
## Problème

`reusable-docker-build.yml` ne logge sur GHCR que dans les jobs `build` et `cosign`. Les jobs **`trivy`** et **`sbom`** tirent l'image sans authentification — ce qui marche pour une image publique, mais **échoue sur une image privée** :

```
syft scan ghcr.io/ferrlabs/actions-runner@sha256:… → exit code 1
```

Constaté sur `FerrLabs/actions-runner-image` (image privée) : `Build & push` ✅ mais `Trivy` ❌ et `SBOM` ❌, et `cosign` skip (il dépend de `trivy`).

## Fix

Ajoute la même étape `docker/login-action` (déjà présente dans `cosign`) en tête des jobs `trivy` et `sbom`, conditionnée à `startsWith(inputs.image-name, 'ghcr.io/')`. Trivy et Syft lisent `~/.docker/config.json` pour le pull.

Additif et sans effet pour les images publiques (le login GITHUB_TOKEN fonctionne aussi). Débloque tous les consommateurs privés (actions-runner-image, Finance, …).