### PR TITLE
fix: make trivy SARIF upload best-effort for repos without advanced security

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -129,7 +129,12 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
       - name: Upload SARIF
+        # Best-effort: code scanning upload needs GitHub Advanced Security,
+        # which isn't available on private repos without a GHAS licence. The
+        # real gate is trivy's exit-code:1 above; don't fail the build just
+        # because the Security-tab integration is unavailable.
         if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Problème

Suite de #70. Sur un repo **privé sans GitHub Advanced Security** (ex. `actions-runner-image`), le scan Trivy réussit mais l'étape `Upload SARIF` (`github/codeql-action/upload-sarif`) échoue :

```
##[error]Resource not accessible by integration — .../workflow-runs#get-a-workflow-run
```

Le code scanning (upload SARIF) nécessite GHAS, indisponible sur repo privé sans licence. Résultat : le job `Trivy` est rouge et `cosign` (qui dépend de `trivy`) est skip — alors que **le scan CVE lui-même est passé**.

## Fix

`continue-on-error: true` sur l'étape `Upload SARIF`. Le vrai garde-fou reste le `exit-code: '1'` de `trivy-action` (échoue le build sur CRITICAL/HIGH corrigeables). L'intégration onglet Security devient best-effort : elle fonctionne là où GHAS est actif, et n'échoue plus le build là où il ne l'est pas. Débloque `cosign` en aval.