### PR TITLE
feat: add trivy-exit-code input to gate or report-only CVE scans

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -36,6 +36,11 @@ on:
         type: string
         required: false
         default: 'CRITICAL,HIGH'
+      trivy-exit-code:
+        description: "Exit code when trivy finds matching vulns ('1' = gate the build, '0' = report-only). Base-derived images with unpatchable upstream CVEs use '0'."
+        type: string
+        required: false
+        default: '1'
       push:
         description: 'Push the image to the registry'
         type: boolean
@@ -127,7 +132,7 @@ jobs:
           output: trivy-results.sarif
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
-          exit-code: '1'
+          exit-code: ${{ inputs.trivy-exit-code }}
       - name: Upload SARIF
         # Best-effort: code scanning upload needs GitHub Advanced Security,
         # which isn't available on private repos without a GHAS licence. The


### PR DESCRIPTION
Suite de #70/#71. Permet aux consommateurs de choisir si Trivy **bloque** le build ou reste **report-only**.

- Nouvel input `trivy-exit-code` (défaut `'1'` → comportement strict inchangé pour les images applicatives).
- Câblé sur `trivy-action.exit-code`.

Cas d'usage : les images dérivées d'une grosse base upstream (ex. `actions-runner` qui embarque .NET/node/go) ont des CVE CRITICAL/HIGH non corrigeables localement ; elles passent `trivy-exit-code: '0'` pour scanner+rapporter sans bloquer chaque release (et débloquer `cosign` qui dépend du job `trivy`).