### PR TITLE
fix: make build-provenance attestation best-effort

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -165,7 +165,13 @@ jobs:
         run: |
           cosign sign --yes \
             "${{ inputs.image-name }}@${{ needs.build.outputs.digest }}"
-      - uses: actions/attest-build-provenance@v4
+      - name: Attest build provenance
+        # Best-effort: GitHub artifact attestations are an org-plan feature
+        # ("Feature not available for the … organization" otherwise). The
+        # cosign keyless signature above is the real signing; don't fail the
+        # build (and skip cosign) just because native provenance is off.
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ inputs.image-name }}
           subject-digest: ${{ needs.build.outputs.digest }}


### PR DESCRIPTION
Dernier maillon pour un build vert sur repo privé. La signature `cosign` keyless réussit, mais l'étape suivante `actions/attest-build-provenance` échoue :

```
Error: Failed to persist attestation: Feature not available for the FerrLabs organization.
```

Les attestations d'artefacts GitHub sont une fonctionnalité d'org/plan non activée — l'image est déjà **signée par cosign**, on ne veut pas faire échouer le job (donc tout le pipeline) pour la provenance native. `continue-on-error: true` sur cette étape (même approche que l'upload SARIF Trivy en #71). Fonctionne là où la feature est active, best-effort sinon.