### PR TITLE
ci: pin third-party actions by commit SHA in reusable workflows

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -71,8 +71,8 @@ jobs:
     # job below stays on the configured (self-hosted) runner.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: hadolint/hadolint-action@v3.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ${{ inputs.context }}/${{ inputs.dockerfile }}
           failure-threshold: warning
@@ -84,17 +84,17 @@ jobs:
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to GHCR
         if: startsWith(inputs.image-name, 'ghcr.io/')
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         id: push
         with:
           context: ${{ inputs.context }}
@@ -120,12 +120,12 @@ jobs:
       # private GHCR image fails with a 401/manifest-unknown.
       - name: Login to GHCR
         if: startsWith(inputs.image-name, 'ghcr.io/')
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aquasecurity/trivy-action@0.35.0
+      - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ inputs.image-name }}:${{ inputs.tag }}
           format: sarif
@@ -140,7 +140,7 @@ jobs:
         # because the Security-tab integration is unavailable.
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy
@@ -151,10 +151,10 @@ jobs:
     if: inputs.push
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: sigstore/cosign-installer@v4.1.2
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Login to GHCR
         if: startsWith(inputs.image-name, 'ghcr.io/')
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -171,7 +171,7 @@ jobs:
         # cosign keyless signature above is the real signing; don't fail the
         # build (and skip cosign) just because native provenance is off.
         continue-on-error: true
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ inputs.image-name }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -187,12 +187,12 @@ jobs:
       # a private GHCR image needs this login or the scan fails to fetch it.
       - name: Login to GHCR
         if: startsWith(inputs.image-name, 'ghcr.io/')
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ inputs.image-name }}@${{ needs.build.outputs.digest }}
           format: cyclonedx-json

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -47,7 +47,7 @@ jobs:
     name: SonarQube analysis
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history so SonarQube can attribute new-code and blame.
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
       # to projectBaseDir) and the lcov's own SF: paths both resolve correctly.
       - name: Download coverage report
         if: inputs.coverage-artifact != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         continue-on-error: true
         with:
           name: ${{ inputs.coverage-artifact }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Download coverage reports (multi-component)
         if: inputs.coverage-artifact-pattern != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         continue-on-error: true
         with:
           pattern: ${{ inputs.coverage-artifact-pattern }}
@@ -73,7 +73,7 @@ jobs:
           path: ${{ inputs.working-directory }}/.sonarcov
 
       - name: SonarQube scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.ferrlabs.com' }}


### PR DESCRIPTION
Durcissement appro (point 4 de la revue) : toutes les actions **tierces** des reusables sont épinglées par **commit SHA** (avec `# vX` conservé pour que Renovate continue de les bumper).

**`reusable-docker-build.yml`** : checkout, hadolint, setup-qemu, setup-buildx, login-action, build-push-action, trivy-action, codeql-action/upload-sarif, cosign-installer, attest-build-provenance, sbom-action.
**`reusable-sonarqube-scan.yml`** : checkout, download-artifact, sonarqube-scan-action.

Empêche qu'un tag mobile (`@v4`) compromis injecte du code dans le pipeline de build/scan/sign. Les refs first-party (`FerrLabs/*`) ne sont volontairement pas figées (on les contrôle, et `@main` doit continuer à recevoir les correctifs).