### PR TITLE
feat(ci): add extra-tags input to reusable-docker-build

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -31,6 +31,11 @@ on:
         type: string
         required: false
         default: ''
+      extra-tags:
+        description: 'Additional full image refs to tag, newline-separated (e.g. ghcr.io/ferrlabs/foo:sha-<gitsha> for traceability). Appended to <image-name>:<tag> and <image-name>:latest.'
+        type: string
+        required: false
+        default: ''
       trivy-severity:
         description: 'Trivy severities that fail the build'
         type: string
@@ -106,6 +111,7 @@ jobs:
           tags: |
             ${{ inputs.image-name }}:${{ inputs.tag }}
             ${{ inputs.image-name }}:latest
+            ${{ inputs.extra-tags }}
           build-args: ${{ inputs.build-args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Closes #75

Adds an optional `extra-tags` input (newline-separated full image refs) appended to the `<image>:<tag>` + `<image>:latest` tags. Empty default → no-op for existing consumers. Lets repos add a git-SHA tag (`sha-<gitsha>`) for immutable, commit-traceable images.

Unblocks actions-runner-image#17 (reproducible/auditable builds).