### PR TITLE
feat: auto-merge patch/minor Kubernetes infra updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -156,6 +156,23 @@
       "groupName": "Docker images"
     },
     {
+      "description": "Kubernetes infra (Flux HelmReleases, Helm charts, manifest image tags) — auto-merge patch+minor after the 1-day quarantine. Majors stay manual (rule below).",
+      "matchManagers": [
+        "flux",
+        "helmv3",
+        "helm-values",
+        "kubernetes"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "minimumReleaseAge": "1 day",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
       "description": "Major updates — always manual",
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
Comble un trou de la config Renovate partagée : aucune règle ne couvrait les managers **`flux` / `helmv3` / `helm-values` / `kubernetes`**, donc les bumps de charts Helm (traefik, vault-secrets-operator, gitlab-runner…) et de tags d'image dans les manifests retombaient sur le défaut `automerge: false` → merge manuel à perpétuité.

Ajoute une règle : **patch+minor** de ces managers → `automerge` (squash) après la quarantaine de **1 jour**. Les **majors restent manuels** (règle existante, placée après). Aligne le comportement infra k8s sur celui déjà en place pour npm/cargo/actions/Docker.