### PR TITLE
ci: run Renovate every 5 minutes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,7 +31,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
Réduit le cron Renovate de 15 à 5 minutes (`*/5 * * * *`) pour une détection/auto-merge plus réactive. Tourne sur `ubuntu-latest` (GitHub-hosted) → pas d'impact sur le pool de runners self-hosted.