### PR TITLE
ci: disable Renovate dependency dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,9 +3,9 @@
   "extends": [
     "config:recommended",
     "mergeConfidence:all-badges",
-    ":semanticCommits",
-    ":dependencyDashboard"
+    ":semanticCommits"
   ],
+  "dependencyDashboard": false,
   "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "1 day",
   "prConcurrentLimit": 10,


### PR DESCRIPTION
Le **Dependency Dashboard** (issue récurrente de Renovate) fait du bruit pour rien. On le désactive : retrait du preset `:dependencyDashboard` + `dependencyDashboard: false`.

Les vrais problèmes restent signalés : Renovate ouvre toujours une **issue dédiée en cas d'erreur de config** (indépendante du dashboard). Les dashboards existants (kubernetes #31, Infra #84, actions-runner-image #15, FerrFlow #422) seront **auto-fermés** par Renovate au prochain passage.