### PR TITLE
feat(ci): auto-select runner by repo visibility in reusables

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -8,9 +8,9 @@ on:
         type: string
         default: '.'
       runner:
-        description: 'GitHub Actions runner label'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
-        default: 'ubuntu-latest'
+        default: ''
       node-version:
         type: string
         default: '24'
@@ -98,7 +98,7 @@ permissions:
 jobs:
   build:
     name: Build & Check
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -138,7 +138,7 @@ jobs:
   i18n:
     name: i18n parity
     if: inputs.enable-i18n
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -166,7 +166,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -8,9 +8,9 @@ on:
         type: string
         default: '.'
       runner:
-        description: 'GitHub Actions runner label'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
-        default: 'ubuntu-latest'
+        default: ''
       go-version-file:
         description: 'Path to go.mod (relative to working-directory)'
         type: string
@@ -92,7 +92,7 @@ permissions:
 jobs:
   detect:
     name: Detect Go module
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -117,7 +117,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -155,7 +155,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -208,7 +208,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -244,7 +244,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -8,9 +8,9 @@ on:
         type: string
         default: '.'
       runner:
-        description: 'GitHub Actions runner label'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
-        default: 'ubuntu-latest'
+        default: ''
       node-version:
         description: 'Node.js version'
         type: string
@@ -134,7 +134,7 @@ permissions:
 jobs:
   test:
     name: Test & Build
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -215,7 +215,7 @@ jobs:
   quality:
     name: Quality (knip, madge, audit)
     if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -8,9 +8,9 @@ on:
         type: string
         default: '.'
       runner:
-        description: 'GitHub Actions runner label'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
-        default: 'ubuntu-latest'
+        default: ''
       rust-toolchain:
         description: 'Rust toolchain (stable, nightly, beta, or pinned version)'
         type: string
@@ -137,7 +137,7 @@ jobs:
       !inputs.skip-on-release-commit ||
       github.event_name != 'push' ||
       !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -180,7 +180,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -241,7 +241,7 @@ jobs:
   typos:
     name: Typos
     if: inputs.enable-typos
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@master
@@ -256,7 +256,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -23,10 +23,10 @@ on:
         required: false
         default: ''
       runner:
-        description: 'GitHub Actions runner label for the upload + publish jobs. Defaults to `ubuntu-latest` so public-repo consumers run on free GitHub-hosted runners.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
         required: false
-        default: 'ubuntu-latest'
+        default: ''
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -109,7 +109,7 @@ jobs:
   upload:
     name: Attest + upload assets
     needs: build
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
@@ -133,7 +133,7 @@ jobs:
     name: Publish crates.io
     needs: upload
     if: inputs.crate-publish
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -24,10 +24,10 @@ on:
         required: false
         default: false
       runner:
-        description: 'GitHub Actions runner label. Defaults to `ubuntu-latest` so public-repo consumers run on free GitHub-hosted runners. Private consumers can override with `ferrlabs-k8s` for the heavier self-hosted pool.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
         required: false
-        default: 'ubuntu-latest'
+        default: ''
       run-on-private:
         description: 'Set to `true` to run the scans on private repos too. Defaults to `false` because GitHub-hosted runners consume billed minutes on private repos and our security scans are best-effort hygiene, not blocking gates. Public repos always run (Actions are free for them).'
         type: boolean
@@ -41,7 +41,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@v6
@@ -83,7 +83,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@v6
@@ -134,7 +134,7 @@ jobs:
 
   trufflehog:
     name: trufflehog (secrets, deep history)
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (!github.event.repository.private || inputs.run-on-private) }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -8,9 +8,9 @@ on:
   workflow_call:
     inputs:
       runner:
-        description: 'Runner label'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
-        default: 'ferrlabs-k8s'
+        default: ''
       working-directory:
         description: 'Project root to analyse (sonar.projectBaseDir)'
         type: string
@@ -45,7 +45,7 @@ permissions:
 jobs:
   sonarqube:
     name: SonarQube analysis
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:


### PR DESCRIPTION
Closes #82

The `runner` input on the CI reusables now defaults to empty, which auto-selects by `github.event.repository.private`:
- **public repo** → `ubuntu-latest` (free GitHub-hosted; and crucially the only thing that *works* — the self-hosted group rejects public repos)
- **private repo** → self-hosted: `ferrlabs-k8s-large` for build/test jobs, `ferrlabs-k8s` for light jobs (lint, i18n, scans, sonar, attest/publish)
- explicit `runner:` still overrides everywhere; missing `github.event.repository` (exotic triggers) falls back to `ubuntu-latest`

Applied to ci-rust, ci-go, ci-node, ci-astro, sonarqube-scan, security-scan, release-rust. **reusable-docker-build is intentionally unchanged** (ubuntu-latest): buildx + `docker/login-action` in every job need a Docker daemon the rootless-buildah self-hosted runners don't provide.

Follow-up (separate, per-consumer): repos currently passing `runner: ferrlabs-k8s` explicitly can drop it to get the build→large tiering; not required for correctness.