### PR TITLE
feat: add zizmor GitHub Actions security scan to reusable security-scan

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
         default: false
+      fail-on-actions:
+        description: 'Fail the workflow on any GitHub Actions security finding from zizmor'
+        type: boolean
+        required: false
+        default: false
       runner:
         description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
         type: string
@@ -130,6 +135,46 @@ jobs:
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner
+        continue-on-error: true
+
+  zizmor:
+    name: zizmor (GitHub Actions security)
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    if: ${{ !github.event.repository.private || inputs.run-on-private }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install zizmor
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: '1'
+        run: |
+          python3 -m pip install --user zizmor==1.25.2
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/zizmor" --version
+      - name: Run zizmor
+        env:
+          # Enables zizmor's online audits (e.g. unpinned/unhashed action refs).
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$(ls -A .github/workflows 2>/dev/null)" ]; then
+            echo "No .github/workflows — nothing for zizmor to scan."
+            exit 0
+          fi
+          set +e
+          zizmor --format sarif . > zizmor.sarif
+          EXIT=$?
+          set -e
+          if [ "${{ inputs.fail-on-actions }}" = "true" ]; then
+            exit $EXIT
+          fi
+          if [ "$EXIT" != "0" ]; then
+            echo "::warning::zizmor found GitHub Actions security issues — see the Security tab. Set fail-on-actions: true to make this blocking."
+          fi
+      - name: Upload SARIF
+        if: always() && hashFiles('zizmor.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor
         continue-on-error: true
 
   trufflehog:

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -159,15 +159,16 @@ jobs:
             echo "No .github/workflows — nothing for zizmor to scan."
             exit 0
           fi
-          set +e
-          zizmor --format sarif . > zizmor.sarif
-          EXIT=$?
-          set -e
-          if [ "${{ inputs.fail-on-actions }}" = "true" ]; then
-            exit $EXIT
-          fi
-          if [ "$EXIT" != "0" ]; then
-            echo "::warning::zizmor found GitHub Actions security issues — see the Security tab. Set fail-on-actions: true to make this blocking."
+          # zizmor exits 0 in SARIF mode even with findings, so gate on the
+          # finding count rather than the exit code.
+          zizmor --format sarif . > zizmor.sarif || true
+          COUNT=$(jq '[.runs[0].results[]] | length' zizmor.sarif 2>/dev/null || echo 0)
+          echo "zizmor findings: $COUNT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::warning::zizmor found $COUNT GitHub Actions security finding(s) — see the Security tab (SARIF). Set fail-on-actions: true to make this blocking."
+            if [ "${{ inputs.fail-on-actions }}" = "true" ]; then
+              exit 1
+            fi
           fi
       - name: Upload SARIF
         if: always() && hashFiles('zizmor.sarif') != ''


### PR DESCRIPTION
Ajoute l'analyse de sécurité des **GitHub Actions** à la reusable `security-scan` (SonarQube ne couvre pas les workflows ; CodeQL-actions n'était que sur `.github`). Tous les consommateurs (FerrFlow, FerrVault, *-Cloud, Infra…) en bénéficient d'un coup.

**Job `zizmor`** ([zizmor](https://github.com/zizmorcore/zizmor) 1.25.2, via pip) :
- détecte injection de template `${{ }}` dans `run:`, permissions trop larges, actions non-épinglées (online audit via `GH_TOKEN`), triggers dangereux (`pull_request_target`), artifact/cache poisoning, etc.
- même style que les autres jobs : sélection runner par visibilité, gate privé/`run-on-private`, SARIF best-effort (`continue-on-error`, GHAS requis pour l'upload), **non bloquant par défaut**.
- nouvel input **`fail-on-actions`** (défaut `false`) pour rendre le gate bloquant si voulu.

Skip propre si le repo n'a pas de `.github/workflows`.