### PR TITLE
fix(renovate): disable platformAutomerge so automerge works without branch protection

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,7 @@
   "labels": [
     "dependencies"
   ],
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "onboardingConfig": {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [


### PR DESCRIPTION
Closes #86

`platformAutomerge: true` uses GitHub's native auto-merge, which can only be armed when a branch-protection rule blocks the merge. No repo has branch protection, so Renovate PRs are immediately mergeable, GitHub refuses to arm auto-merge, and PRs pile up green-but-unmerged (e.g. Kit #88, #84, #85, #86).

Setting `platformAutomerge: false` makes Renovate merge via its own API call once checks pass — works without branch protection. On the next Renovate run after this merges, the backlog of green, quarantine-passed PRs should clear.