### PR TITLE
feat(renovate): re-enable platformAutomerge with branch protection in place

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,7 @@
   "labels": [
     "dependencies"
   ],
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "onboardingConfig": {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [


### PR DESCRIPTION
Reverts the #87 stopgap now that repos have branch-protection rulesets (required checks + ferrflow bypass). With required checks present, GitHub native auto-merge can be armed, so Renovate PRs auto-merge once green. Part of the org-wide branch-protection rollout.