### PR TITLE
ci: add reusable FerrFlow release workflow with visibility-aware runner

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -1,0 +1,75 @@
+name: Reusable — FerrFlow Release
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: >-
+          Override the runner label. Empty (default) auto-selects by repo
+          visibility: private repos use the self-hosted ferrlabs-k8s pool,
+          public repos use ubuntu-latest. This is what lets a repo flip
+          private <-> public without editing its release workflow.
+        type: string
+        required: false
+        default: ''
+      fetch-depth:
+        description: 'Checkout fetch-depth. 0 (full history) is required for commit analysis and changelog generation.'
+        type: number
+        required: false
+        default: 0
+      dry-run:
+        description: 'Run FerrFlow without creating releases or pushing changes.'
+        type: boolean
+        required: false
+        default: false
+      force-version:
+        description: 'Force a specific version (VERSION, or NAME@VERSION for monorepos). Empty = analyse commits.'
+        type: string
+        required: false
+        default: ''
+      trigger-renovate:
+        description: 'After a real release, dispatch the org Renovate scan so downstream consumers pick up the new version.'
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      RENOVATE_TOKEN:
+        required: false
+      FERRLABS_DISPATCH_TOKEN:
+        required: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Release with FerrFlow
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: FerrLabs/FerrFlow@v5
+        with:
+          dry_run: ${{ inputs.dry-run }}
+          force_version: ${{ inputs.force-version }}
+          bot: true
+
+  trigger-renovate:
+    name: Trigger Renovate scan on consumers
+    needs: release
+    if: ${{ inputs.trigger-renovate && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    steps:
+      - name: Dispatch Renovate workflow
+        env:
+          GH_TOKEN: ${{ secrets.RENOVATE_TOKEN || secrets.FERRLABS_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RENOVATE_TOKEN / FERRLABS_DISPATCH_TOKEN not set — skipping Renovate trigger."
+            exit 0
+          fi
+          gh workflow run renovate.yml -R FerrLabs/.github

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -48,10 +48,11 @@ jobs:
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: FerrLabs/FerrFlow@v5
+          persist-credentials: false
+      - uses: FerrLabs/FerrFlow@39550d4d65cb2a09192bef70a3257e1d80c795ad # v5
         with:
           dry_run: ${{ inputs.dry-run }}
           force_version: ${{ inputs.force-version }}

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -20,17 +20,7 @@ concurrency:
 
 jobs:
   release:
-    name: Run FerrFlow
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(release):')) ||
-      github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: FerrLabs/FerrFlow@v5
-        with:
-          dry_run: ${{ inputs.dry_run || false }}
-          bot: true
+    uses: FerrLabs/.github/.github/workflows/reusable-ferrflow-release.yml@main
+    with:
+      dry-run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
Adds `reusable-ferrflow-release.yml` — a single source of truth for cutting a FerrFlow release.\n\n**Why:** repos that hardcode `runs-on: ferrlabs-k8s` break when flipped private -> public (self-hosted runners aren't usable on public repos). The reusable auto-selects the runner by `github.event.repository.private` (override via `runner` input), so visibility flips need no workflow change. It also pins `FerrFlow@v5` + `bot: true` in one place, guards chore(release) self-triggers, and fixes the `dry-run` vs `dry_run` input mismatch.\n\nInputs: `runner`, `fetch-depth` (default 0), `dry-run`, `force-version`, `trigger-renovate`. Caller stays a thin stub (`workflow-templates/release.yml` updated to demonstrate).\n\nConsumer-repo migrations will follow in per-repo PRs.\n\nCloses 92