### PR TITLE
ci: add Kellnr cargo registry host rule for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -147,5 +147,10 @@ jobs:
                 "matchHost": "github.com",
                 "hostType": "git-refs",
                 "token": "${{ steps.app-token.outputs.token }}"
+              },
+              {
+                "matchHost": "crates.ferrlabs.com",
+                "hostType": "cargo",
+                "token": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
               }
             ]


### PR DESCRIPTION
Adds a `hostRules` entry for **crates.ferrlabs.com** (`hostType: cargo`, read-only org token) to `RENOVATE_HOST_RULES`, so Renovate can authenticate to the private Kellnr index and open/automerge PRs for the `ferrlabs-*` crates now consumed from the registry (the existing `^ferrlabs-` cargo rule handles automerge).

The git-refs `customManager` for `Kit.git` rev pins stays for now — it still bumps consumers that haven't migrated yet; we remove it once they're all on the registry.