### PR TITLE
chore(renovate): remove PR concurrency and hourly limits

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,8 +8,8 @@
   "dependencyDashboard": false,
   "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "1 day",
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 4,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Renovate defaults cap open PRs (`prConcurrentLimit`) and PRs opened per hour (`prHourlyLimit`). With many repos extending this shared preset and a backlog of pending updates, those caps throttle how fast updates land.

Set both to `0` (Renovate's value for *no limit*) in the org preset `default.json`, so every repo extending `github>FerrLabs/.github` picks it up:

- `prConcurrentLimit`: 10 → 0
- `prHourlyLimit`: 4 → 0

The existing safety gates are unchanged — `minimumReleaseAge` quarantine, merge-confidence requirements, the 3-day GitHub Actions wait, and manual-only majors all still apply. This only lifts the count/rate ceiling, not the trust rules.