### PR TITLE
feat(ci): support packages-read secret mount in reusable docker build

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -65,6 +65,10 @@ on:
       digest:
         description: 'Image digest (sha256:...)'
         value: ${{ jobs.build.outputs.digest }}
+    secrets:
+      packages-read:
+        description: 'GHCR token with read:packages, for installing private @ferrlabs/* npm or other authenticated fetches during the build. Exposed to BuildKit as a secret (id=packages-read) via --mount=type=secret, never as a build-arg, so it never lands in an image layer or the build log. In the Dockerfile: RUN --mount=type=secret,id=packages-read,env=NODE_AUTH_TOKEN pnpm install.'
+        required: false
 
 permissions:
   contents: read
@@ -115,6 +119,7 @@ jobs:
           push: false
           tags: ${{ inputs.image-name }}:smoke
           build-args: ${{ inputs.build-args }}
+          secrets: ${{ secrets.packages-read != '' && format('packages-read={0}', secrets.packages-read) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Smoke test
@@ -136,6 +141,7 @@ jobs:
             ${{ inputs.image-name }}:latest
             ${{ inputs.extra-tags }}
           build-args: ${{ inputs.build-args }}
+          secrets: ${{ secrets.packages-read != '' && format('packages-read={0}', secrets.packages-read) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Part of #95 (P0 prerequisite #2 — secret build-arg support).

## Why
Product image builds need to install private `@ferrlabs/*` npm packages from GHCR, which requires a `read:packages` token (`NODE_AUTH_TOKEN`). The bespoke Buildah `docker.yml` builds pass it today; `reusable-docker-build.yml` only had a plaintext `build-args` input, and passing a token through `build-args` **leaks it into image layers and build logs**. That gap was the blocker stopping product repos from migrating to the reusable (buildx) workflow.

## What
- New optional `secrets.packages-read` on the `workflow_call`.
- Both `build-push-action` steps (smoke build + push) now receive it via the `secrets:` input, which BuildKit exposes as `--mount=type=secret,id=packages-read` — never a build-arg, so it never lands in a layer or the log.
- Passed conditionally: when a consumer doesn't supply the secret, an empty string is passed and no secret is created, so existing callers (FerrFlow, public images) are unaffected.

```
secrets: ${{ secrets.packages-read != '' && format('packages-read={0}', secrets.packages-read) || '' }}
```

## Consumer side (follow-up, per-repo PRs — not this PR)
Each migrating repo passes `secrets: { packages-read: ${{ secrets.FERRFLOW_PACKAGES_READ }} }` and switches its Dockerfile from `ARG NODE_AUTH_TOKEN` to:
```dockerfile
RUN --mount=type=secret,id=packages-read,env=NODE_AUTH_TOKEN pnpm install --frozen-lockfile
```

## Status of the other P0 items in #95
- **#1 (merge reusable to main):** already done — `reusable-docker-build.yml` is on `main`. The issue text is stale on this point.
- **#3 (platforms per package)** and **#4 (changelog prefetch):** handled per-repo at migration time (the workflow already exposes `platforms`).

Validated: YAML parses; no change to behaviour for callers that don't pass the secret. Real validation is FerrVault-Cloud's next release once its migration PR lands (the reference migration in #95).