### PR TITLE
fix(ci): pin crate-ci/typos to v1 instead of mutable @master

### DIFF
--- a/workflow-templates/ci-rust.yml
+++ b/workflow-templates/ci-rust.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@v1
 
   coverage:
     name: Coverage


### PR DESCRIPTION
Closes #62.

`workflow-templates/ci-rust.yml` pinned the only third-party action in the templates to a mutable branch (`crate-ci/typos@master`), contradicting the templates' own convention (`actions/checkout@v6`, `taiki-e/install-action@v2`, `ossf/scorecard-action@v2.4.0`, …) and tripping OpenSSF Scorecard's Pinned-Dependencies check. Since these templates are copied verbatim into every Rust repo, a push to `typos`' `master` — malicious or not — would run org-wide in a job that has already checked out the repo source.

Pinned to the `@v1` major tag (typos publishes a moving `v1`), matching the major-tag style the other template actions use.

Audited the rest of `workflow-templates/`: the only remaining non-tag refs are `FerrLabs/.github/...@main` (our own first-party reusables — intended), so the acceptance criterion 'no template references a mutable branch for a third-party action' holds.