### PR TITLE
chore(renovate): set recreateWhen=always so closed PRs regenerate with current config

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
   ],
   "dependencyDashboard": false,
   "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "always",
   "minimumReleaseAge": "1 day",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,


### PR DESCRIPTION
Follow-up to #101 (PR limits lifted).

## Problem
Renovate's default `recreateWhen: "auto"` treats a user-closed PR as "don't want this update" and will **not** recreate it at the same version. That makes the natural way to re-apply changed org config — close the stale PRs and let the bot rebuild them — silently drop the backlog instead of refreshing it.

## Change
Set `recreateWhen: "always"` in the shared preset `default.json`. Now a closed Renovate PR (or deleted branch) is regenerated on the next run with the **current** preset (labels, grouping, automerge, limits, schedules) — which is exactly what we want when the org config changes.

## Why this is safe here
- The org runs Renovate fully automated under `ferrlabs-renovate[bot]` with the Dependency Dashboard intentionally off, so there's no human-curated "closed = ignore" workflow to preserve.
- `minimumReleaseAge` quarantine, merge-confidence gates, and manual-major rules are unchanged — this only affects *recreation of closed branches*, not what's eligible.

This is the prerequisite for refreshing the existing ~100-PR backlog onto the new config (close → bot recreates with current preset).