### PR TITLE
ci(release): install Rust + Kellnr token for cargo postBump hooks

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -52,7 +52,17 @@ jobs:
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
           persist-credentials: false
+      # Rust workspaces (the -Cloud api packages) carry a FerrFlow postBump
+      # hook that runs `cargo update` to sync Cargo.lock after the version
+      # bump. The release runner has no Rust by default, so install it when the
+      # repo has a Cargo.toml.
+      - if: ${{ hashFiles('**/Cargo.toml') != '' }}
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: FerrLabs/FerrFlow@39550d4d65cb2a09192bef70a3257e1d80c795ad # v5
+        env:
+          # Lets cargo-based postBump hooks read the private Kellnr index.
+          # Empty (and unused) for repos that don't consume Kellnr.
+          CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
         with:
           dry_run: ${{ inputs.dry-run }}
           force_version: ${{ inputs.force-version }}


### PR DESCRIPTION
## Why
The -Cloud repos with a Rust `api` package configure a FerrFlow `postBump` hook that runs `cargo update -p <api> --manifest-path api/Cargo.toml` to sync `Cargo.lock` after a version bump. The release runner has no Rust toolchain, so the hook fails:

```
▸ [post_bump] cargo update -p ferrvault-api --manifest-path api/Cargo.toml
sh: 1: cargo: not found
error[E6001]: hook [post_bump] failed (exit 127)
```

This breaks `main` on FerrVault-Cloud right now (every api version bump hits it), and would hit FerrTrack/FerrGrowth/FerrLens/FerrFleet the same way.

## What
In `reusable-ferrflow-release.yml`, before the FerrFlow step:
- Install Rust (`dtolnay/rust-toolchain@stable`, SHA-pinned) **only when the repo has a `Cargo.toml`** (`hashFiles('**/Cargo.toml') != ''`) — no cost for non-Rust repos.
- Expose `CARGO_REGISTRIES_KELLNR_TOKEN` to the FerrFlow step so a cargo hook can read the private Kellnr index (empty/unused where the secret isn't set).

`cargo update -p <crate>` only re-pins the local crate; no compilation, so no C toolchain needed.

## Blast radius
Shared workflow — used by every repo's release (Kit, all -Cloud, FerrFlow). Change is additive and conditional; non-Rust releases are unaffected (Rust step skipped, env var empty). Leaving review/merge to you given the scope.

> Note: the consuming repo's hook must run where its `.cargo/config.toml` lives (e.g. `cd api && cargo update -p <crate>`) so the Kellnr registry is discovered — handled per-repo (FerrVault-Cloud follow-up).