### PR TITLE
ci: bump FerrFlow action pin to v5.7.0

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -58,7 +58,7 @@ jobs:
       # repo has a Cargo.toml.
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: FerrLabs/FerrFlow@604314baca1e832428e4d8061de9eb7133853b29 # v5
+      - uses: FerrLabs/FerrFlow@f6b2a3c7b80b7bc8d63a1b5ac9bf8111a6b5bfa4 # v5.7.0
         env:
           # Lets cargo-based postBump hooks read the private Kellnr index.
           # Empty (and unused) for repos that don't consume Kellnr.


### PR DESCRIPTION
@
## What

Bumps the FerrFlow action pin in the reusable release workflow from `604314b # v5` to the v5.7.0 release commit `f6b2a3c # v5.7.0`.

## Why

The action installs the `latest` FerrFlow binary at runtime, so behaviour already tracks the newest release — but the pinned wrapper SHA and its `# v5` comment were stale (predating the publishers feature) and misleading. This realigns the wrapper with the binary it installs. Relevant now that Kit publishes to Kellnr through FerrFlow declarative publishers (FerrLabs/Kit#120).

The `v5` floating tag in FerrLabs/FerrFlow is stuck at v5.2.3 and does not track newer v5.x releases (tracked separately), so this uses the explicit v5.7.0 release commit rather than the floating tag.

Closes #109
@