### PR TITLE
chore(renovate): enable lockFileMaintenance (keeps browserslist/caniuse-lite fresh)

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,13 @@
   "minimumReleaseAge": "1 day",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "squash"
+  },
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Why

`caniuse-lite` (the data behind Browserslist) is a **transitive** dependency, so Renovate's normal updates never bump it — it goes stale and every Angular/Vite build prints `Browserslist: caniuse-lite is outdated`. Confirmed present in the lockfiles (FerrLabs-Cloud, FerrGrowth-Cloud, …).

Rather than a bespoke browserslist-only GitHub Action (which would re-plumb token + PR + CI just to run `update-browserslist-db`), the right lever is the org's **existing** Renovate automation — it already opens PRs, runs CI, and auto-merges under a proper App token. It was only missing `lockFileMaintenance`.

## What

Added `lockFileMaintenance` to the shared preset (`default.json`, extended by every repo):
```json
"lockFileMaintenance": { "enabled": true, "schedule": ["before 6am on monday"], "automerge": true, "automergeType": "pr", "automergeStrategy": "squash" }
```

Weekly, Renovate regenerates each lockfile — refreshing `caniuse-lite` **and** every other transitive — and auto-merges when green. This is the documented Renovate way to keep caniuse-lite current, org-wide, in one place. Existing safety gates (minimumReleaseAge, merge-confidence, manual-majors) are unchanged; lockfile maintenance only refreshes resolutions within existing semver ranges.