### PR TITLE
ci(rust): wire Kellnr registry token into reusable-ci-rust.yml

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -122,6 +122,8 @@ on:
         required: false
       SONAR_TOKEN:
         required: false
+      CARGO_REGISTRIES_KELLNR_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -133,6 +135,8 @@ env:
 jobs:
   test:
     name: Test
+    env:
+      CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
     if: |
       !inputs.skip-on-release-commit ||
       github.event_name != 'push' ||
@@ -181,6 +185,8 @@ jobs:
 
   security:
     name: Cargo Security
+    env:
+      CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
     if: |
       (inputs.enable-audit || inputs.enable-deny || inputs.enable-machete) && (
         !inputs.skip-on-release-commit ||
@@ -257,6 +263,8 @@ jobs:
 
   coverage:
     name: Coverage
+    env:
+      CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
     if: |
       inputs.enable-coverage && (
         !inputs.skip-on-release-commit ||


### PR DESCRIPTION
Closes #112

## Quoi

Ajoute `CARGO_REGISTRIES_KELLNR_TOKEN` (secret optionnel) au workflow réutilisable `reusable-ci-rust.yml`, injecté en `env` au niveau des 3 jobs qui résolvent/compilent des crates : **Test**, **Cargo Security**, **Coverage**.

## Pourquoi

C'est le seul chaînon manquant qui empêche les API produits (FerrGrowth, FerrTrack, FerrVault, FerrLens, FerrFleet, FerrLabs-Cloud) d'adopter ce réutilisable : ils consomment les crates privées `ferrlabs-*` depuis Kellnr et ont donc chacun forké un `Check API` maison (fmt → clippy → `build --release`, **sans `cargo test`**, double compile debug+release → gaspille sccache/garage).

## Sûreté

- Secret `required: false` → vide quand non fourni. **Aucun impact pour Kit** (seul consommateur actuel, qui n'en a pas besoin — il *est* la source des crates).
- Pas de nouveau job, pas de changement de comportement par défaut.
- YAML validé (`yaml.safe_load`).

Débloque la migration de tous les `Check API` maison vers le réutilisable (issues de suivi par repo à venir).