### PR TITLE
ci(renovate): declare Kellnr cargo registry so lockfile updates resolve

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -114,6 +114,13 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: ${{ inputs.repoFilter || 'FerrLabs/*' }}
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
+          # Private Kellnr cargo registry, declared via env so Renovate's
+          # `cargo update` lockfile runs resolve it. The registry lives in each
+          # repo's api/.cargo/config.toml, but Renovate invokes cargo from the
+          # repo root where that subdir config isn't discovered ("registry index
+          # was not found: kellnr") — env vars are honoured regardless of cwd.
+          CARGO_REGISTRIES_KELLNR_INDEX: "sparse+https://crates.ferrlabs.com/api/v1/crates/"
+          CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
           # Identity of every commit / PR / issue Renovate makes. Format
           # `<numeric-app-id>+<bot-slug>[bot]@users.noreply.github.com`
           # is the GitHub-canonical bot author. The numeric prefix is


### PR DESCRIPTION
Closes #114

## Problème

Renovate abandonne les PRs Cargo des repos consommant Kellnr (FerrVault#309 aws-config, FerrGrowth, …) : `cargo update` échoue avec `registry index was not found in any configuration: kellnr`.

Renovate lance `cargo update` depuis la **racine** du repo, mais `[registries.kellnr]` vit dans `api/.cargo/config.toml` — invisible depuis la racine (cargo remonte le CWD, ne descend pas). Donc le lockfile ne peut pas être régénéré → PR abandonnée.

## Fix

Déclare le registre + token Kellnr en env dans le workflow Renovate (honoré par cargo quel que soit le CWD). Fix **central**, répare tous les repos d'un coup :

```yaml
CARGO_REGISTRIES_KELLNR_INDEX: "sparse+https://crates.ferrlabs.com/api/v1/crates/"
CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
```

Le secret est déjà accessible au workflow (la host-rule l'utilise déjà). Après merge, le prochain run Renovate (cron 5 min) rebase les PRs `- abandoned`.