### PR TITLE
ci(renovate): read GHCR @ferrlabs/* npm via GITHUB_TOKEN not App token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -114,6 +114,13 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: ${{ inputs.repoFilter || 'FerrLabs/*' }}
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
+          # Private Kellnr cargo registry, declared via env so Renovate's
+          # `cargo update` lockfile runs resolve it. The registry lives in each
+          # repo's api/.cargo/config.toml, but Renovate invokes cargo from the
+          # repo root where that subdir config isn't discovered ("registry index
+          # was not found: kellnr") — env vars are honoured regardless of cwd.
+          CARGO_REGISTRIES_KELLNR_INDEX: "sparse+https://crates.ferrlabs.com/api/v1/crates/"
+          CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
           # Identity of every commit / PR / issue Renovate makes. Format
           # `<numeric-app-id>+<bot-slug>[bot]@users.noreply.github.com`
           # is the GitHub-canonical bot author. The numeric prefix is

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -60,6 +60,12 @@ jobs:
     # Renovate only needs node + network reach to npm/crates.io/GHCR, no
     # cluster-side resources.
     runs-on: ubuntu-latest
+    # packages: read lets this job's GITHUB_TOKEN pull the private @ferrlabs/*
+    # GHCR npm packages (App installation tokens can't read GHCR — known
+    # limitation). Each package must list FerrLabs/.github under "Manage
+    # Actions access" for this token to be granted.
+    permissions:
+      packages: read
     steps:
       # Mint a short-lived (1h) installation token from the GitHub App.
       # Replaces the long-lived PAT we used previously — commits and PRs
@@ -77,14 +83,14 @@ jobs:
 
       - name: Probe GHCR npm read access (informational)
         env:
-          TOKEN: ${{ steps.app-token.outputs.token }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           status=$(curl -sS -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${TOKEN}" \
             "https://npm.pkg.github.com/@ferrlabs%2Fui-astro")
           if [ "${status}" = "200" ]; then
-            echo "ok — App token can read @ferrlabs/* on GHCR (${status})"
+            echo "ok — GITHUB_TOKEN can read @ferrlabs/* on GHCR (${status})"
           else
             # Downgraded to warning: this probe historically false-positived
             # when the App had Packages:read granted AND the consumer repos
@@ -94,13 +100,9 @@ jobs:
             # the packages — if it can't, the next run will just skip
             # @ferrlabs/* updates silently, which is recoverable.
             echo "::warning::Probe returned ${status} from npm.pkg.github.com." \
-                 "If Renovate doesn't open @ferrlabs/* PRs, double-check:" \
-                 "(1) App has Repository → Packages → Read-only at" \
-                 "https://github.com/organizations/FerrLabs/settings/apps/ferrlabs-renovate/permissions" \
-                 "(2) installation has no pending permission accept at" \
-                 "https://github.com/organizations/FerrLabs/settings/installations" \
-                 "(3) each private @ferrlabs/* GHCR npm package lists .github" \
-                 "under Settings → Manage Actions access."
+                 "GITHUB_TOKEN can't read @ferrlabs/* — verify each @ferrlabs/*" \
+                 "GHCR package lists FerrLabs/.github under Settings → Manage" \
+                 "Actions access, and that this job keeps permissions: packages: read."
           fi
 
       - name: Run Renovate
@@ -128,22 +130,20 @@ jobs:
           # the bot-id env var is set from the token-mint step's output.
           RENOVATE_GIT_AUTHOR: "${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.app-token.outputs.bot-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           RENOVATE_USERNAME: "${{ steps.app-token.outputs.app-slug }}[bot]"
-          # Auth for GHCR npm registry (where @ferrlabs/* live).
-          # Without this, lookups for @ferrlabs/ui, @ferrlabs/ui-astro,
-          # @ferrlabs/ui-foundation fail with `no-result` because Renovate
-          # tries npmjs.org by default. The packageRule in default.json
-          # overrides registryUrls to npm.pkg.github.com; this token lets
-          # us actually authenticate against it.
-          # Same token is used by the github-actions hostRule for cross-repo
-          # actions (octokit calls when resolving release notes for things
-          # like FerrLabs/UI tags) and by the git-refs datasource fetching
-          # FerrLabs/Kit refs/heads/main.
+          # Auth for GHCR npm registry (where @ferrlabs/* live). The npm
+          # hostRule uses GITHUB_TOKEN (not the App token): App installation
+          # tokens can't read GHCR packages, but a repo's GITHUB_TOKEN can when
+          # the package grants FerrLabs/.github "Manage Actions access". The
+          # packageRule in default.json points registryUrls at npm.pkg.github.com.
+          # The github-tags / git-refs hostRules below keep the App token for
+          # cross-repo octokit calls (release notes) and the git-refs datasource
+          # fetching FerrLabs/Kit refs/heads/main.
           RENOVATE_HOST_RULES: |
             [
               {
                 "matchHost": "npm.pkg.github.com",
                 "hostType": "npm",
-                "token": "${{ steps.app-token.outputs.token }}"
+                "token": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "matchHost": "github.com",


### PR DESCRIPTION
Closes #116

## Quoi

La host-rule npm de Renovate passe du **token d'App** (`ghs_…`) au **`GITHUB_TOKEN`** du job, et le job gagne `permissions: packages: read`.

## Pourquoi

Les tokens d'installation d'App **ne lisent pas** les packages GHCR (limite connue) → 403 permanent sur `@ferrlabs/*`, quels que soient la permission App, la visibilité Internal ou "Manage Actions access" (qui ne profite qu'au `GITHUB_TOKEN` d'un repo). Le `GITHUB_TOKEN` de `.github`, lui, lit les packages qui listent `FerrLabs/.github` dans leur Actions access.

## Validé

Run dispatché sur la branche : probe `ok — GITHUB_TOKEN can read @ferrlabs/* on GHCR (200)`, **0** × `ERR_PNPM_FETCH_403` (contre 15 avant). Les host-rules github-tags/git-refs gardent le token d'App.