### PR TITLE
ci(renovate): run every 30 minutes instead of every 5

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,7 +31,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
Closes #118.

Switches the Renovate workflow cron from `*/5 * * * *` to `*/30 * * * *`. The per-package `@ferrlabs/*` rule keeps its internal `* * * * *` schedule; effective scan cadence follows the 30-min invocation.