### PR TITLE
chore(ci): retry buildah manifest push on transient GHCR errors (default 3)

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -56,6 +56,11 @@ on:
         type: boolean
         required: false
         default: true
+      push-retries:
+        description: 'How many times to retry each manifest push if the registry returns a transient error (5xx, network reset). Backoff is 10s, 30s, 90s, … capped at 5 min. Set to 1 to disable retries.'
+        type: number
+        required: false
+        default: 3
       runner:
         description: 'GitHub Actions runner label for the build job (the heavy one). Private consumers pass `ferrlabs-k8s`; public consumers leave the default.'
         type: string
@@ -120,6 +125,7 @@ jobs:
           BUILD_ARGS: ${{ inputs.build-args }}
           EXTRA_TAGS: ${{ inputs.extra-tags }}
           PUSH: ${{ inputs.push }}
+          PUSH_RETRIES: ${{ inputs.push-retries }}
           SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
           PACKAGES_READ: ${{ secrets.packages-read }}
         run: |
@@ -156,12 +162,36 @@ jobs:
             exit 0
           fi
 
-          buildah manifest push --all --digestfile "$RUNNER_TEMP/digest" \
+          # GHCR push periodically returns 504 Gateway Timeout or resets the
+          # connection mid-manifest. The build itself is fine; only the manifest
+          # upload flaps. Retry each push N times with exponential backoff
+          # (10s, 30s, 90s, capped at 300s) before failing the job.
+          retries="${PUSH_RETRIES:-3}"
+          retry_push() {
+            local attempt=1
+            local delay=10
+            while true; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$retries" ]; then
+                echo "::error::manifest push failed after $attempt attempt(s): $*"
+                return 1
+              fi
+              echo "::warning::manifest push attempt $attempt failed, retrying in ${delay}s"
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 3))
+              [ "$delay" -gt 300 ] && delay=300
+            done
+          }
+
+          retry_push buildah manifest push --all --digestfile "$RUNNER_TEMP/digest" \
             "$IMAGE:$TAG" "docker://$IMAGE:$TAG"
-          buildah manifest push --all "$IMAGE:$TAG" "docker://$IMAGE:latest"
+          retry_push buildah manifest push --all "$IMAGE:$TAG" "docker://$IMAGE:latest"
           while IFS= read -r ref; do
             [ -z "$ref" ] && continue
-            buildah manifest push --all "$IMAGE:$TAG" "docker://$ref"
+            retry_push buildah manifest push --all "$IMAGE:$TAG" "docker://$ref"
           done <<< "${EXTRA_TAGS:-}"
 
           echo "digest=$(cat "$RUNNER_TEMP/digest")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

The `reusable-docker-build.yml` workflow occasionally fails at the manifest-push step with a transient GHCR error — the build itself completes fine, then the upload of the manifest gets a `504 Gateway Timeout` or has its connection reset:

```
Writing manifest to image destination
Error: pushing image "ghcr.io/ferrlabs/ferrlens-cloud/site:latest" to "docker://...":
writing manifest: ... received unexpected HTTP status: 504 Gateway Timeout
##[error]Process completed with exit code 125.
```

Recent example: [ferrlens-cloud release Docker run](https://github.com/FerrLabs/FerrLens-Cloud/actions/runs/28199358999/job/83534537185) — primary tag pushed cleanly, `:latest` push received 504 after the GHCR 10-min wait.

Right now this fails the whole job and we have to manually rerun the workflow.

## What

New input `push-retries` (default `3`). The `buildah manifest push` calls go through a small `retry_push` wrapper that catches the exit code and retries with exponential backoff (10s → 30s → 90s, capped at 300s). On the final failure the job exits non-zero with an `::error::` annotation pointing at the failing push.

Applies uniformly to all three push sites:
- Primary tag (`$IMAGE:$TAG`)
- `:latest` alias
- Each entry of `extra-tags` (loop)

Set `push-retries: 1` in a caller to disable.

## Behaviour matrix

| Outcome | Before | After (default 3) |
|---|---|---|
| Push succeeds first try | ✅ | ✅ (same code path) |
| Single 504 then succeeds | ❌ job red | ✅ warning + retry |
| Three consecutive 504s | ❌ job red | ❌ job red with annotation |
| Push fails for non-transient reason (e.g. auth) | ❌ job red | ❌ still red — but waits ~2 min before giving up |

## Test plan

- [ ] CI on this PR runs the workflow on itself if applicable; manually trigger a Docker build downstream once merged.
- [ ] Verify the input is optional — existing callers that don't pass `push-retries` keep their old behaviour with the new default of 3.

## Notes

- Total worst-case extra wait when GHCR is genuinely down: `10 + 30 + 90 = 130s` per push, ~6.5 min if all three push sites fail. Acceptable for a release pipeline.
- Doesn't touch the build step itself — that's deterministic, no need to retry.
- Doesn't touch Trivy, cosign, SBOM jobs — those pull from the registry, not push; if GHCR is flaky on read those have their own action-level retries.