### PR TITLE
ci(docker): stop DL3008/DL3018 OS-package-pin lints from failing builds

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -95,6 +95,10 @@ jobs:
         with:
           dockerfile: ${{ inputs.context }}/${{ inputs.dockerfile }}
           failure-threshold: warning
+          # DL3008 (apt) / DL3018 (apk): pinning OS package versions is
+          # impractical — Debian/Alpine point releases supersede them and exact
+          # pins break the build. Every other warning still fails the gate.
+          ignore: DL3008,DL3018
 
   build:
     name: Build & push


### PR DESCRIPTION
Docker builds were failing org-wide at the hadolint step in the reusable `reusable-docker-build.yml`: DL3008 (pin apt versions) and DL3018 (pin apk versions) are warnings, and the gate is `failure-threshold: warning`.

Adds `ignore: DL3008,DL3018` to the hadolint step. Pinning OS package versions is impractical (Debian/Alpine point releases supersede them; exact pins break the build) — same reasoning already applied inline in FerrLabs-Cloud's bff Dockerfile. Every other hadolint warning still fails the gate.

Since consumers reference this workflow `@main`, the fix applies to all repos on their next Docker run. Failed release builds (FerrLabs-Cloud api/site/bff, FerrVault api/site, FerrFlow v6.18.x, …) can then be re-run.

Closes #124