### PR TITLE
ci(docker): run cosign on ubuntu-latest (self-hosted runner lacks envsubst)

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -239,7 +239,11 @@ jobs:
     name: cosign (sign + attest)
     needs: [build, trivy]
     if: inputs.push
-    runs-on: ${{ inputs.runner }}
+    # cosign-installer needs `envsubst` (gettext), which the minimal self-hosted
+    # ARC runners don't ship — it fails with "envsubst: command not found".
+    # Signing only touches the remote GHCR digest, so pin to a GitHub-hosted
+    # runner (same rationale as the hadolint job above).
+    runs-on: ubuntu-latest
     steps:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Login to GHCR


### PR DESCRIPTION
Builds now get past hadolint + build + push and fail only at **cosign (sign + attest)**: `envsubst: command not found` (exit 127). `sigstore/cosign-installer` needs gettext's `envsubst`, absent on the minimal self-hosted ARC runner.

Pins the cosign job to `ubuntu-latest` (has envsubst; signing only touches the remote GHCR digest, so no self-hosted runner needed) — same pattern as the hadolint job. Applies org-wide via `@main`; this is the third and final blocker after #125 (hadolint) and the per-repo buildah secret-mount fixes.

Closes #126