### PR TITLE
feat: OpenGrep SAST + import SAST/secret findings into SonarQube

### DIFF
--- a/.github/actions/sast-external-issues/action.yml
+++ b/.github/actions/sast-external-issues/action.yml
@@ -1,0 +1,92 @@
+name: SAST → SonarQube external issues
+description: >-
+  Run OpenGrep (SAST) and gitleaks (secrets) on the checked-out repo and convert
+  their SARIF into the SonarQube Generic Issue Import format, so the findings
+  surface as external issues on the SonarQube project (dashboard consolidation,
+  no DefectDojo). Complements the SARIF the security-scan workflow already sends
+  to the GitHub Security tab. Outputs the sonar-scanner arg to wire into the
+  scan step.
+
+inputs:
+  working-directory:
+    description: 'Project root that will be analysed (must match sonar.projectBaseDir).'
+    required: false
+    default: '.'
+  sast-config:
+    description: >-
+      OpenGrep ruleset — a path/URL passed to `opengrep scan -f`. Empty (default)
+      shallow-clones the community `opengrep/opengrep-rules` set, since OpenGrep
+      bundles no rules and the Semgrep registry `auto` shorthand is not reliably
+      available on the fork.
+    required: false
+    default: ''
+  opengrep-version:
+    description: 'Pinned OpenGrep release version.'
+    required: false
+    default: '1.9.0'
+  gitleaks-version:
+    description: 'Pinned gitleaks release version (kept in sync with reusable-security-scan).'
+    required: false
+    default: '8.21.2'
+  output-file:
+    description: 'Report path, relative to working-directory, for the generic issue JSON.'
+    required: false
+    default: 'sonar-external-issues.json'
+
+outputs:
+  scanner-args:
+    description: 'sonar-scanner arg enabling the external issues report (empty string if nothing was produced).'
+    value: ${{ steps.convert.outputs.args }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install OpenGrep + gitleaks
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/sast-bin"
+        curl -fsSL "https://github.com/opengrep/opengrep/releases/download/v${{ inputs.opengrep-version }}/opengrep_manylinux_x86" \
+          -o "$RUNNER_TEMP/sast-bin/opengrep"
+        curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${{ inputs.gitleaks-version }}/gitleaks_${{ inputs.gitleaks-version }}_linux_x64.tar.gz" \
+          | tar -xz -C "$RUNNER_TEMP/sast-bin" gitleaks
+        chmod +x "$RUNNER_TEMP/sast-bin/opengrep" "$RUNNER_TEMP/sast-bin/gitleaks"
+        echo "$RUNNER_TEMP/sast-bin" >> "$GITHUB_PATH"
+
+    - name: Run scanners + convert to Sonar generic issues
+      id: convert
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SAST_CONFIG: ${{ inputs.sast-config }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        # Report-only: the scanners never fail this action. Blocking gates stay
+        # the caller's job (fail-on-* in reusable-security-scan / the quality gate).
+        set +e
+        if [ -n "$SAST_CONFIG" ]; then
+          RULES="$SAST_CONFIG"
+        else
+          git clone --depth 1 https://github.com/opengrep/opengrep-rules.git "$RUNNER_TEMP/opengrep-rules" \
+            && RULES="$RUNNER_TEMP/opengrep-rules"
+        fi
+        if [ -n "${RULES:-}" ]; then
+          opengrep scan --sarif-output=opengrep.sarif -f "$RULES" .
+        else
+          echo "::warning::Could not resolve an OpenGrep ruleset — skipping SAST, keeping secrets scan."
+        fi
+        gitleaks detect --source . --redact --report-format sarif --report-path gitleaks.sarif
+        set -e
+
+        FILES=""
+        [ -s opengrep.sarif ] && FILES="$FILES opengrep.sarif"
+        [ -s gitleaks.sarif ] && FILES="$FILES gitleaks.sarif"
+        if [ -n "$FILES" ]; then
+          jq -s -f "$GITHUB_ACTION_PATH/sarif-to-sonar.jq" $FILES > "$OUTPUT_FILE"
+          echo "args=-Dsonar.externalIssuesReportPaths=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+          echo "SAST → SonarQube external issues summary:"
+          jq '{rules: (.rules | length), issues: (.issues | length)}' "$OUTPUT_FILE"
+        else
+          echo "args=" >> "$GITHUB_OUTPUT"
+          echo "No SARIF produced — no external issues to import."
+        fi

--- a/.github/actions/sast-external-issues/sarif-to-sonar.jq
+++ b/.github/actions/sast-external-issues/sarif-to-sonar.jq
@@ -1,0 +1,74 @@
+# SARIF -> SonarQube Generic Issue Import Format (Clean Code taxonomy).
+#
+# Usage:  jq -s -f sarif-to-sonar.jq a.sarif b.sarif > out.json
+#
+# Consumes one or more SARIF 2.1.0 documents (slurped into a top-level array)
+# and emits { "rules": [...], "issues": [...] } consumable by SonarQube via
+# `-Dsonar.externalIssuesReportPaths`. Every issue's ruleId is guaranteed to
+# have a matching rule (rules are synthesised from the results themselves and
+# enriched with the SARIF driver rule metadata when present).
+#
+# Kept deliberately jq-only (no python/pip) so it runs on the self-hosted
+# ferrlabs-k8s pool as well as ubuntu-latest.
+
+def sev(l):
+  if   l == "error"   then "HIGH"
+  elif l == "warning" then "MEDIUM"
+  else "LOW" end;
+
+# Normalise a SARIF artifact URI into a project-relative path.
+def relpath(u):
+  (u // "unknown") | sub("^file://"; "") | sub("^\\./"; "");
+
+# All runs across every slurped SARIF document.
+[ .[] | .runs[]? ] as $runs
+
+# Rule metadata map keyed by "<engine>:<ruleId>".
+| ( reduce ( $runs[]
+             | (.tool.driver.name // "sast") as $e
+             | (.tool.driver.rules // [])[]
+             | { k: ($e + ":" + (.id // "unknown")), v: . }
+           ) as $r ({}; .[$r.k] = $r.v) ) as $meta
+
+# Flatten every result, tagging it with its engine + composite rule id.
+| ( [ $runs[]
+      | (.tool.driver.name // "sast") as $e
+      | .results[]?
+      | { engine: $e, rid: ($e + ":" + (.ruleId // "unknown")), res: . } ] ) as $results
+
+| {
+    rules: (
+      [ $results[] | { engine, rid } ] | unique_by(.rid)
+      | map(
+          .rid as $rid | .engine as $e | ($meta[$rid] // {}) as $m
+          | {
+              id: $rid,
+              name: (($m.name // $m.id // ($rid | sub("^[^:]+:"; ""))) | tostring),
+              engineId: $e,
+              cleanCodeAttribute: "CONVENTIONAL",
+              impacts: [ { softwareQuality: "SECURITY",
+                           severity: sev($m.defaultConfiguration.level // "warning") } ],
+              description: (($m.shortDescription.text // $m.fullDescription.text // $m.name // "Security finding") | tostring)
+            }
+        )
+    ),
+    issues: (
+      [ $results[]
+        | .rid as $rid | .res as $res
+        | ($res.locations[0].physicalLocation) as $pl
+        | select($pl != null)
+        | {
+            ruleId: $rid,
+            primaryLocation: {
+              message: (($res.message.text // "Security finding") | tostring),
+              filePath: relpath($pl.artifactLocation.uri),
+              textRange: (
+                { startLine: ($pl.region.startLine // 1) }
+                + ( if ($pl.region.endLine // 0) > ($pl.region.startLine // 1)
+                    then { endLine: $pl.region.endLine } else {} end )
+              )
+            }
+          }
+      ]
+    )
+  }

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: ''
+      sast-config:
+        description: 'OpenGrep ruleset for the SAST job. A path/URL passed to `opengrep scan -f`. Empty (default) shallow-clones the community `opengrep/opengrep-rules` set.'
+        type: string
+        required: false
+        default: ''
       osv-scan-args:
         description: 'Extra args for osv-scanner'
         type: string
@@ -25,6 +30,11 @@ on:
         default: false
       fail-on-actions:
         description: 'Fail the workflow on any GitHub Actions security finding from zizmor'
+        type: boolean
+        required: false
+        default: false
+      fail-on-sast:
+        description: 'Fail the workflow on any SAST finding from OpenGrep'
         type: boolean
         required: false
         default: false
@@ -145,6 +155,65 @@ jobs:
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner
+        continue-on-error: true
+
+  opengrep:
+    name: opengrep (SAST)
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    if: ${{ !github.event.repository.private || inputs.run-on-private }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install OpenGrep
+        run: |
+          VERSION=1.9.0
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL "https://github.com/opengrep/opengrep/releases/download/v${VERSION}/opengrep_manylinux_x86" \
+            -o "$RUNNER_TEMP/bin/opengrep"
+          chmod +x "$RUNNER_TEMP/bin/opengrep"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/opengrep" --version
+      - name: Resolve ruleset
+        id: rules
+        env:
+          SAST_CONFIG: ${{ inputs.sast-config }}
+        run: |
+          if [ -n "$SAST_CONFIG" ]; then
+            echo "path=$SAST_CONFIG" >> "$GITHUB_OUTPUT"
+          else
+            # OpenGrep bundles no rules; the Semgrep registry `auto` shorthand is
+            # not reliably available on the fork, so we ship the community set.
+            git clone --depth 1 https://github.com/opengrep/opengrep-rules.git "$RUNNER_TEMP/opengrep-rules"
+            echo "path=$RUNNER_TEMP/opengrep-rules" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run OpenGrep
+        run: |
+          set +e
+          opengrep scan \
+            --sarif-output=opengrep.sarif \
+            --error \
+            -f "${{ steps.rules.outputs.path }}" \
+            .
+          EXIT=$?
+          set -e
+          echo "opengrep exit: $EXIT"
+          # opengrep/semgrep: 0 = clean, 1 = findings, >=2 = internal error.
+          if [ "$EXIT" -ge 2 ]; then
+            echo "::warning::OpenGrep errored (exit $EXIT) — not failing the scan."
+            exit 0
+          fi
+          if [ "$EXIT" = "1" ]; then
+            echo "::warning::OpenGrep found SAST issues — see the Security tab (SARIF). Set fail-on-sast: true to make this blocking."
+            if [ "${{ inputs.fail-on-sast }}" = "true" ]; then
+              exit 1
+            fi
+          fi
+          exit 0
+      - name: Upload SARIF
+        if: always() && hashFiles('opengrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: opengrep.sarif
+          category: opengrep
         continue-on-error: true
 
   zizmor:

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -35,6 +35,14 @@ on:
         description: 'Glob of coverage artifacts to download+merge into <working-directory>/.sonarcov (one project, several components). Each artifact should carry a uniquely-named, repo-root-rebased lcov; point reportPaths at .sonarcov/<name>.lcov via args.'
         type: string
         default: ''
+      sast:
+        description: 'Run OpenGrep (SAST) + gitleaks and import their findings into SonarQube as external issues (dashboard consolidation). Report-only — never fails the scan on its own.'
+        type: boolean
+        default: false
+      sast-config:
+        description: 'OpenGrep ruleset for the SAST import (path/URL for `opengrep scan -f`). Empty clones the community opengrep/opengrep-rules set.'
+        type: string
+        default: ''
     secrets:
       SONAR_TOKEN:
         required: true
@@ -72,6 +80,18 @@ jobs:
           merge-multiple: true
           path: ${{ inputs.working-directory }}/.sonarcov
 
+      # OpenGrep (SAST) + gitleaks → SonarQube external issues. Report-only; the
+      # findings surface on the Sonar project alongside the SARIF the security-scan
+      # workflow already sends to the GitHub Security tab. Runs before the scan so
+      # the generated report is on disk when sonar-scanner reads it.
+      - name: SAST → SonarQube external issues
+        id: sast
+        if: inputs.sast
+        uses: FerrLabs/.github/actions/sast-external-issues@main
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          sast-config: ${{ inputs.sast-config }}
+
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
         env:
@@ -82,4 +102,5 @@ jobs:
           args: >
             -Dsonar.projectKey=${{ inputs.project-key || github.event.repository.name }}
             -Dsonar.exclusions=${{ inputs.exclusions }}
+            ${{ steps.sast.outputs.scanner-args }}
             ${{ inputs.args }}


### PR DESCRIPTION
## Contexte

Complète la stack AppSec FerrLabs. Une partie de la liste demandée existait déjà (gitleaks, osv-scanner, trufflehog, scan Sonar) — cette PR ne livre que le **delta réel** côté CI.

## Changements

### 1. OpenGrep (SAST) — nouveau job dans `reusable-security-scan.yml`
- Binaire épinglé `opengrep_manylinux_x86` v1.9.0 (même pattern que gitleaks/osv)
- Règles communautaires `opengrep/opengrep-rules` (clonées) ; surchargeable via l'input `sast-config`
- SARIF → onglet **GitHub Security** (report-only ; `fail-on-sast` optionnel)

### 2. Remontée dans SonarQube — composite action `sast-external-issues`
- Lance OpenGrep + gitleaks et convertit le SARIF en **Generic Issue Import Format** Sonar (taxonomie Clean Code)
- Convertisseur **jq pur** (`sarif-to-sonar.jq`), aucune dépendance python/pip → tourne aussi sur `ferrlabs-k8s`
- Packagé en composite action pour que le script soit récupéré via `$GITHUB_ACTION_PATH` (un workflow réutilisable ne voit pas les fichiers frères du repo `.github` à l'exécution)

### 3. `reusable-sonarqube-scan.yml`
- Nouveaux inputs `sast` (bool, défaut `false`) et `sast-config`
- Quand `sast: true` : l'action tourne avant le scan et injecte `-Dsonar.externalIssuesReportPaths=…`

## Résultat
Les findings OpenGrep/gitleaks apparaissent **à la fois** dans l'onglet GitHub Security (SARIF) **et** dans SonarQube comme external issues → dashboard unique, pas besoin de DefectDojo.

## Activation
Report-only et **opt-in** : les consommateurs passent `sast: true` au workflow Sonar. Rien n'est bloquant par défaut. À activer ensuite repo par repo (comme `enable-sonar`).

## Points de vigilance à valider
- Version OpenGrep 1.9.0 (à confirmer vs dernière release) et flag `--error`
- Le clone de `opengrep/opengrep-rules` (repo volumineux) — shallow, mais premier run un peu long