### PR TITLE
fix(ci): correct sast-external-issues action path

### DIFF
--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -87,7 +87,7 @@ jobs:
       - name: SAST → SonarQube external issues
         id: sast
         if: inputs.sast
-        uses: FerrLabs/.github/actions/sast-external-issues@main
+        uses: FerrLabs/.github/.github/actions/sast-external-issues@main
         with:
           working-directory: ${{ inputs.working-directory }}
           sast-config: ${{ inputs.sast-config }}


### PR DESCRIPTION
The SonarQube reusable workflow's SAST-import step fails on every consuming repo with:

`Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action 'FerrLabs/.github/actions/sast-external-issues@main'.`

The composite action lives at `.github/actions/sast-external-issues/` in this repo, but the `uses:` referenced `FerrLabs/.github/actions/...` — GitHub parses that as repo `FerrLabs/.github` + path `actions/...` (repo root), so it looks in the wrong place. Every other in-repo action (e.g. `setup-sccache`) is correctly referenced with the doubled prefix `FerrLabs/.github/.github/actions/...`.

Fix: add the missing `.github/` segment so the path resolves to `.github/actions/sast-external-issues`.
