### PR TITLE
fix(renovate): pin bot user id in RENOVATE_GIT_AUTHOR so rebase isn't blocked

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -153,12 +153,16 @@ jobs:
           # was not found: kellnr") — env vars are honoured regardless of cwd.
           CARGO_REGISTRIES_KELLNR_INDEX: "sparse+https://crates.ferrlabs.com/api/v1/crates/"
           CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
-          # Identity of every commit / PR / issue Renovate makes. Format
-          # `<numeric-app-id>+<bot-slug>[bot]@users.noreply.github.com`
-          # is the GitHub-canonical bot author. The numeric prefix is
-          # what GitHub needs to attribute correctly in the timeline UI;
-          # the bot-id env var is set from the token-mint step's output.
-          RENOVATE_GIT_AUTHOR: "${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.app-token.outputs.bot-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          # Identity Renovate must recognise as its own so it keeps
+          # auto-rebasing its PRs instead of assuming a human edited them.
+          # Must byte-match the author GitHub attributes to the App bot when
+          # it commits via the API: `<bot-user-id>+<slug>[bot]@users.noreply.github.com`.
+          # create-github-app-token exposes no bot/user-id output (only token,
+          # installation-id, app-slug), so the previous `outputs.bot-id` was
+          # empty — the malformed author never matched the real commits and
+          # Renovate blocked every rebase. The bot user id (282300760) is
+          # immutable for this App, so it is pinned here.
+          RENOVATE_GIT_AUTHOR: "${{ steps.app-token.outputs.app-slug }}[bot] <282300760+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           RENOVATE_USERNAME: "${{ steps.app-token.outputs.app-slug }}[bot]"
           # Auth for GHCR npm registry (where @ferrlabs/* live). The npm
           # hostRule uses GITHUB_TOKEN (not the App token): App installation


### PR DESCRIPTION
## Problem

Every Renovate PR carries "does not recognize the last commit author" and refuses to auto-rebase — on every run — despite all commits being authored by `ferrlabs-renovate[bot]`.

## Cause

`RENOVATE_GIT_AUTHOR` interpolated `steps.app-token.outputs.bot-id`, which **does not exist** on `create-github-app-token@v3` (outputs are `token`, `installation-id`, `app-slug`). The numeric prefix was therefore empty → configured author `...<+ferrlabs-renovate[bot]@...>` never matched the real platform-commit author `...<282300760+ferrlabs-renovate[bot]@...>`, so Renovate treated every branch as human-edited.

## Fix

Pin the App's immutable bot user id (`282300760`) in `RENOVATE_GIT_AUTHOR`. Now the configured identity byte-matches the commits Renovate makes, so it recognises its own branches and resumes auto-rebasing.

Open Renovate PRs recover on their next run (or tick the rebase/retry checkbox to force it once).

Closes #133.