### PR TITLE
fix(renovate): bind shard array before object construction (jq compile error)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -106,13 +106,13 @@ jobs:
             ($tools + $libs + $infra) as $named
             | ($repos | map(select(endswith("-Cloud")))) as $cloud
             | ($repos | map(select((endswith("-Cloud") | not) and (($named | index(.)) | not)))) as $rest
-            | { include:
-                  ($cloud | map({shard: ., filter: ("FerrLabs/" + .)}))
-                  + [ {shard:"tools", filter: flt($tools)},
-                      {shard:"libs",  filter: flt($libs)},
-                      {shard:"infra", filter: flt($infra)} ]
-                  + (if ($rest | length) > 0 then [{shard:"rest", filter: flt($rest)}] else [] end)
-              }')
+            | ( ($cloud | map({shard: ., filter: ("FerrLabs/" + .)}))
+                + [ {shard: "tools", filter: (flt($tools))},
+                    {shard: "libs",  filter: (flt($libs))},
+                    {shard: "infra", filter: (flt($infra))} ]
+                + (if ($rest | length) > 0 then [{shard: "rest", filter: (flt($rest))}] else [] end)
+              ) as $inc
+            | {include: $inc}')
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
 
   renovate:


### PR DESCRIPTION
## Problem

The shard-matrix jq merged in #136 doesn't compile — every scheduled Renovate run aborts at the plan step with `jq: 3 compile errors` (exit 3). jq won't accept an object value that begins a concatenation (`{ include: (map…) + [ … ] + … }`).

The jq fix was pushed to #136's branch **after** the squash-merge, so it never reached main.

## Fix

Bind the concatenated shard array to `$inc`, then construct the object trivially:
```jq
( ($cloud | map(…)) + [ … tools/libs/infra … ] + (if … rest … end) ) as $inc
| {include: $inc}
```

Validated locally with jq 1.8.2 against the committed file: compiles and emits the full 12-shard matrix (8 *-Cloud legs + tools/libs/infra/rest). No behaviour change beyond making it parse.

Closes #137.