### PR TITLE
chore(renovate): use client-id for the App token (app-id deprecated)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,7 +6,7 @@ name: Renovate
 # to whichever human happens to own the PAT.
 #
 # Required org-level secrets (Settings → Secrets and variables → Actions):
-#   - RENOVATE_APP_ID            : GitHub App numeric ID (from app's settings page)
+#   - RENOVATE_APP_CLIENT_ID     : GitHub App Client ID (App settings → "Client ID", e.g. Iv23li…)
 #   - RENOVATE_APP_PRIVATE_KEY   : PEM-encoded private key (full content incl. BEGIN/END lines)
 #
 # To create the App: see the README in this repo or
@@ -68,7 +68,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3 # zizmor: ignore[github-app,unpinned-uses]
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: FerrLabs # zizmor: ignore[github-app]
       # A manual repoFilter collapses to one `manual` shard. A scheduled run
@@ -147,7 +147,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: FerrLabs
 


### PR DESCRIPTION
## What

Silences the `Input 'app-id' has been deprecated — use 'client-id' instead` warnings from `create-github-app-token@v3` (both token-mint steps: plan job + renovate job).

`app-id` → `client-id`, sourced from a new secret `RENOVATE_APP_CLIENT_ID`.

## ⚠️ Do NOT merge before adding the secret

`client-id` reads a **new** org secret that doesn't exist yet. Merging first would make every token mint fail and take Renovate down org-wide.

**Before merging:** add org secret `RENOVATE_APP_CLIENT_ID` (Settings → Secrets and variables → Actions) = the App's **Client ID** from https://github.com/organizations/FerrLabs/settings/apps → the renovate app → "Client ID" (format `Iv23li…`, not the numeric App ID). The old `RENOVATE_APP_ID` secret can stay or be removed afterwards.

`app-id` still works, so there's no rush — this is warning cleanup.

Closes #140.