### PR TITLE
feat(renovate): pin GitHub Action digests org-wide

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "mergeConfidence:all-badges",
-    ":semanticCommits"
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
   ],
   "dependencyDashboard": false,
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Why

Renovate PRs that update a workflow `uses:` (e.g. [FerrVault#167](https://github.com/FerrLabs/FerrVault/pull/167)) always fail the `zizmor` code-scanning gate: bumping `action@vN` to another tag stays **unpinned**, and the repos enforce hash-pinning (`unpinned-uses` = blanket policy). Action-update PRs could never merge.

## What

Adds the built-in preset **`helpers:pinGitHubActionDigests`** to the shared `default.json`. Renovate now pins every action to its commit SHA with the tag as a trailing comment:

```yaml
- uses: actions/checkout@<40-char-sha> # v5
```

and keeps the SHA + comment updated on new releases. Pinned digests satisfy zizmor, so action PRs go green.

Applies org-wide (every repo extends `github>FerrLabs/.github`).

## Heads-up

The next scheduled sweep opens a **one-time wave** of "pin digests" PRs across all repos (one per workflow with unpinned actions). After that, action updates stay pinned. `prConcurrentLimit`/`prHourlyLimit` are already 0 (unlimited), so expect them all at once.

Closes #146.