### PR TITLE
fix(ci): authenticate Trivy DB pull to prevent concurrent GHCR rate-limit

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -216,6 +216,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        # Authenticate the Trivy DB pull from ghcr.io/aquasecurity/trivy-db.
+        # trivy-action already caches the DB (keyed by date), but on the first
+        # scan of the day two images releasing in parallel (App + Render) both
+        # cache-miss and pull the DB at once; anonymous concurrent GHCR pulls
+        # get rate-limited, one scan exits 1 → the cosign job is skipped and the
+        # image ships to GHCR unsigned. TRIVY_USERNAME/PASSWORD makes the DB
+        # pull authenticated (per-account quota instead of per-IP anonymous),
+        # which clears the contention. Note: GITHUB_TOKEN as an env var does NOT
+        # help here — trivy only uses it for GitHub API calls (VEX repos), not
+        # the OCI registry pull of the DB.
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
           image-ref: ${{ inputs.image-name }}:${{ inputs.tag }}
           format: sarif


### PR DESCRIPTION
Closes FerrLabs/Infra#195.

## Problem
On a FerrGrowth release building 2+ images in parallel (App + Render), the App's `Trivy (CVE scan)` passes but the Render image's fails **reproducibly** in the same run. Because the scan job exits 1, the `cosign (sign + attest)` job is skipped → the render image is pushed to GHCR **unsigned** and may fail deploy if signature verification is enforced. Seen on `app@v4.10.1` and `app@v4.11.0`.

## Root cause
`aquasecurity/trivy-action` already caches the vulnerability DB (keyed by date), but on the **first scan of the day** both images cache-miss and pull `ghcr.io/aquasecurity/trivy-db` at the same time. The **anonymous** concurrent GHCR pulls get rate-limited (per-IP quota) — one wins, the other's `trivy` exits 1.

## Fix (issue option 1 — auth the DB pull)
Set `TRIVY_USERNAME`/`TRIVY_PASSWORD` on the Trivy step so the DB pull is **authenticated** (per-account quota instead of per-IP anonymous), clearing the contention. Uses `github.actor` + the built-in `GITHUB_TOKEN` — **no new secret to provision** on the cluster runner.

Notes:
- The built-in DB cache is kept (nothing to add there — that was already present).
- `GITHUB_TOKEN` as a plain env var does *not* help the DB pull; trivy only uses it for GitHub API calls (VEX repos), not the OCI registry pull. The registry-auth path is `TRIVY_USERNAME/PASSWORD`. Ref: aquasecurity/trivy troubleshooting + discussion #8009.
- This lives in the shared `reusable-docker-build.yml`, so the fix applies to **every** product building 2+ images per release.

## Acceptance
Render (and any 2nd concurrent image) passes Trivy and gets cosign-signed on a normal release, no re-runs.

If per-account auth still proves insufficient under heavy concurrency, the fallback is a daily cron that refreshes the DB cache on `main` + `TRIVY_SKIP_DB_UPDATE=true` on scans (Aqua's documented approach) — not needed unless option 1 falls short.