### PR TITLE
fix(ci): pré-compile les tests d'intégration avant de créer la DB per-run

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -269,6 +269,18 @@ jobs:
         with:
           s3-key: ${{ secrets.SCCACHE_S3_KEY }}
           s3-secret: ${{ secrets.SCCACHE_S3_SECRET }}
+      # Compile the test binaries BEFORE creating the throwaway DB. Otherwise the
+      # fresh DB sits with zero connections for the whole build (~10-15 min) and
+      # the hourly postgres-ci GC, which reaps idle `ci_*` databases, can drop it
+      # mid-run (a connectionless DB looks orphaned). Pre-building shrinks the
+      # create→first-connection window to seconds. The GC also has an age guard,
+      # but keeping the window tiny is cheap defense-in-depth. Strip the test
+      # harness args (everything after ` -- `) so only cargo-side flags reach
+      # `--no-run`.
+      - name: Pre-compile integration test binaries
+        env:
+          INTEGRATION_ARGS: ${{ inputs.integration-args }}
+        run: cargo test --no-run ${INTEGRATION_ARGS%% -- *}
       - name: Create per-run database
         env:
           DB_ENV_NAME: ${{ inputs.integration-db-env }}


### PR DESCRIPTION
## Contexte

Complément à [FerrLabs/kubernetes#65](https://github.com/FerrLabs/kubernetes/pull/65). Le job `integration` créait la DB per-run **avant** `cargo test`, qui compile puis exécute. Pendant les ~10-15 min de compilation, la DB restait **sans aucune connexion** → le GC horaire `postgres-ci-gc` pouvait la dropper (elle paraissait orpheline). Résultat : `database "ci_..." does not exist` au moment des tests.

## Correctif

Nouvelle étape **`Pre-compile integration test binaries`** (`cargo test --no-run`) **avant** `Create per-run database`. La fenêtre création→1ʳᵉ connexion passe de ~13 min à quelques secondes. Le garde-fou d'âge du GC (PR #65) reste le vrai correctif ; ceci est une défense en profondeur.

Les args du harness (après ` -- `) sont retirés via `${INTEGRATION_ARGS%% -- *}` pour ne passer que les flags cargo à `--no-run` (validé sur 3 formes d'args).