### PR TITLE
docs(ci): smoke-test-cmd doit utiliser podman (store buildah), pas docker

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -37,7 +37,7 @@ on:
         required: false
         default: ''
       smoke-test-cmd:
-        description: 'Shell command to functionally test the built image before it is pushed. When set, the image is built and loaded locally first (single-platform only — set platforms accordingly), this command runs with $SMOKE_IMAGE pointing at the loaded ref, and the registry push happens only if it passes. Empty = skip.'
+        description: 'Shell command to functionally test the built image before it is pushed. When set, the image is built into the local buildah/containers store (single-platform only — set platforms accordingly), this command runs with $SMOKE_IMAGE pointing at that store ref, and the registry push happens only if it passes. Run it with `podman run "$SMOKE_IMAGE"` — NOT `docker run`: the image is not yet pushed and Docker does not share buildah''s store, so docker would try to pull the missing tag and fail with `manifest unknown`. Empty = skip.'
         type: string
         required: false
         default: ''


### PR DESCRIPTION
Clarifie l'input `smoke-test-cmd` de `reusable-docker-build`. L'image est construite dans le **store buildah/containers** et le smoke test tourne **avant le push**. La doc disait « loaded locally » sans préciser le store → un consommateur (actions-runner-image) a écrit `docker run $SMOKE_IMAGE`, qui ne voit pas l'image buildah et échoue en `manifest unknown` (cf. FerrLabs/actions-runner-image#42).

Précise qu'il faut `podman run "$SMOKE_IMAGE"` (podman partage le store de buildah), pas `docker run`. Doc uniquement, aucun changement de comportement.