### PR TITLE
feat(ci): add reusable Renovate rebase dispatch

### DIFF
--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -1,0 +1,43 @@
+name: Reusable — Renovate rebase dispatch
+
+# Self-hosted Renovate only notices the "rebase/retry" checkbox when it next
+# runs. Ticking the box just edits the PR body — nothing watches that — so with
+# the */30 cron in renovate.yml you wait up to 30 minutes. This turns the edit
+# into an immediate Renovate run scoped to the calling repo via `repoFilter`,
+# which is why it finishes in seconds instead of sweeping the whole org.
+#
+# Callers trigger on `pull_request: types: [edited]` and pass `secrets: inherit`.
+#
+# Requires the org secret RENOVATE_TOKEN: dispatching renovate.yml lives in
+# FerrLabs/.github, and a repo's own GITHUB_TOKEN cannot reach another repo.
+# Soft-passes when unset — the next scheduled run still picks the box up.
+#
+# This cannot loop: Renovate unticks the box once it has rebased, and that
+# second `edited` event no longer matches the guard below.
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Dispatch Renovate
+    if: >-
+      startsWith(github.head_ref, 'renovate/') &&
+      contains(github.event.pull_request.body, '- [x] <!-- rebase-check -->')
+    runs-on: ferrlabs-k8s
+    steps:
+      - name: Trigger a repo-scoped Renovate run
+        env:
+          GH_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RENOVATE_TOKEN not set — skipping. The next scheduled Renovate run will pick up the checkbox."
+            exit 0
+          fi
+          gh workflow run renovate.yml -R FerrLabs/.github -f repoFilter="$REPO"
+          echo "Dispatched a Renovate run scoped to $REPO (requested from PR #$PR)."


### PR DESCRIPTION
Ticking Renovate's rebase/retry checkbox only edits the PR body. Self-hosted Renovate never sees that — it only reads the box on its next run — so with the `*/30` cron you wait up to 30 minutes for something that feels like a button.

This reusable turns the edit into an immediate Renovate run, scoped to the calling repo with the `repoFilter` input `renovate.yml` already exposes, so it finishes in seconds rather than sweeping the org.

Callers add ~6 lines triggering on `pull_request: types: [edited]` with `secrets: inherit`.

Details worth noting:
- **Cannot loop.** Renovate unticks the box after rebasing; that second `edited` event no longer matches the guard.
- **Needs `RENOVATE_TOKEN`** (already an org secret, used by `reusable-ferrflow-release.yml` and `UI/publish.yml`): a repo's own `GITHUB_TOKEN` cannot dispatch a workflow in `FerrLabs/.github`. Soft-passes when unset, so the scheduled run still handles it.
- **`permissions: {}`** — nothing is checked out and no repo scope is needed. The PR body is only read in an `if` guard, never interpolated into `run:`.

Note this does not change auto-rebasing: Renovate already rebases when a PR is behind its base branch. This only makes the manual "do it now / retry" click immediate.

Closes #155