### PR TITLE
fix(ci): let Renovate dispatch callers choose the runner

### DIFF
--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -17,6 +17,11 @@ name: Reusable — Renovate rebase dispatch
 
 on:
   workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
+        type: string
+        default: 'ferrlabs-k8s'
 
 permissions: {}
 
@@ -26,7 +31,7 @@ jobs:
     if: >-
       startsWith(github.head_ref, 'renovate/') &&
       contains(github.event.pull_request.body, '- [x] <!-- rebase-check -->')
-    runs-on: ferrlabs-k8s
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Trigger a repo-scoped Renovate run
         env:


### PR DESCRIPTION
The reusable hardcoded `runs-on: ferrlabs-k8s`, but that runner group sets `allows_public_repositories=false` — so on the seven public repos (`.github`, `Benchmarks`, `Changelog`, `FerrFlow`, `FerrVault`, `Fixtures`, `MCP`) the job would simply never get a runner. `.github` itself is one of them.

Adds a `runner` input defaulting to `ferrlabs-k8s`, matching `reusable-docker-build.yml`. Private callers stay on self-hosted; public ones pass `ubuntu-latest`.

Caught before the org-wide rollout, so no repo ships a job that can't run.

Closes #157