### PR TITLE
fix(ci-node): stop the audit step failing on npm's retired audit endpoint

### DIFF
--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -246,7 +246,20 @@ jobs:
         continue-on-error: true
       - name: audit
         if: inputs.enable-audit
-        run: ${{ inputs.package-manager }} audit --prod --audit-level=${{ inputs.audit-level }}
+        env:
+          PKG_MANAGER: ${{ inputs.package-manager }}
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: |
+          set +e
+          OUT=$("$PKG_MANAGER" audit --prod --audit-level="$AUDIT_LEVEL" 2>&1)
+          EXIT=$?
+          set -e
+          printf '%s\n' "$OUT"
+          if [ "$EXIT" -ne 0 ] && printf '%s' "$OUT" | grep -qE 'responded with 410|endpoint is being retired'; then
+            echo "::warning title=Dependency audit skipped::The npm registry retired the legacy audit endpoints on 2026-07-15, and pnpm only queries the replacement bulk advisory endpoint from v11 onwards. This step cannot gate anything until this repo moves to pnpm 11, so it is reporting a warning instead of failing. Dependency CVEs are still surfaced (advisory-only) by osv-scanner in the security-scan workflow. See https://github.com/pnpm/pnpm/issues/11265"
+            exit 0
+          fi
+          exit $EXIT
 
   sonarqube:
     name: SonarQube


### PR DESCRIPTION
@
The `Quality (knip, madge, audit)` job fails on every open PR across the product repos, and it is a required status check, so nothing can merge.

Closes #161.

## Cause

npm retired the legacy audit endpoints on 2026-07-15 — primary and fallback both return HTTP 410. pnpm only queries the replacement bulk advisory endpoint from v11 onwards (pnpm/pnpm#11265), and every repo here is on pnpm 10, so `pnpm audit` cannot succeed on any commit regardless of content. Reproduced locally on pnpm 10.34.3.

Only the `audit` step is fatal — `knip` and `madge` already have `continue-on-error: true`, so the "Unused files" noise in those logs is a red herring.

## Change

The `audit` step reports a warning and passes **only** when the output carries the retired-endpoint signature (`responded with 410` / `endpoint is being retired`). Everything else still fails the job, and the step is deliberately left without `continue-on-error` so it keeps gating. Once a repo moves to pnpm 11 the bulk endpoint answers and the step becomes a real gate again with no further change.

Inputs are passed via `env:` rather than interpolated into the shell.

## Verification

Behaviour pinned against a stubbed package manager for each case, plus the real pnpm:

| Case | Step exit | Result |
|---|---|---|
| Retired-endpoint 410 | 0 | warning, job continues |
| Real high-severity vulnerability | 1 | still fails |
| Clean audit | 0 | passes |
| Registry 500 (other error) | 1 | still fails, not swallowed |
| **Real pnpm 10.34.3** in FerrTrack-Cloud | 0 | warning path taken |

The 500 case matters: the match is deliberately narrow, so a genuine registry outage is not silently swallowed.

## Caveat

`pnpm audit` was the only blocking dependency-CVE check. `osv-scanner` scans the same `pnpm-lock.yaml` and `Cargo.lock` but `fail-on-cve` defaults to `false`, so it is advisory-only — dependency CVEs are surfaced but not enforced until pnpm 11 lands. Noted in #161; flipping `fail-on-cve: true` needs a per-repo review of current findings first.
@