### PR TITLE
fix(renovate): declare cargo registry via customEnvVariables so cargo receives it

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -183,27 +183,30 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           configurationFile: default.json
-          # The action filters `process.env` through this regex before handing it
-          # to the Renovate container, so anything not matching never reaches
-          # cargo. This is the action's own default with CARGO_REGISTRIES_KELLNR_*
-          # appended — keep the leading alternatives in sync when bumping the
-          # action, or Renovate silently loses LOG_LEVEL / proxy config.
-          env-regex: '^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy|CARGO_REGISTRIES_KELLNR_(?:INDEX|TOKEN))$'
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_AUTODISCOVER: "true"
           RENOVATE_AUTODISCOVER_FILTER: ${{ matrix.filter }}
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
-          # Private Kellnr cargo registry, declared via env so Renovate's
-          # `cargo update` lockfile runs resolve it. The registry lives in each
-          # repo's api/.cargo/config.toml, but Renovate invokes cargo from the
-          # repo root where that subdir config isn't discovered ("registry index
-          # was not found: kellnr") — env vars are honoured regardless of cwd.
-          # Declaring them here is necessary but not sufficient: they only reach
-          # the container because `env-regex` above allows them through.
-          CARGO_REGISTRIES_KELLNR_INDEX: "sparse+https://crates.ferrlabs.com/api/v1/crates/"
-          CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
+          # Private Kellnr cargo registry, needed so Renovate's `cargo update`
+          # lockfile runs resolve it. The registry lives in each repo's
+          # api/.cargo/config.toml, but Renovate invokes cargo from the repo root
+          # where that subdir config isn't discovered ("registry index was not
+          # found: kellnr"), so it has to come from the environment.
+          #
+          # It must go through customEnvVariables rather than a plain `env:`
+          # entry: Renovate builds the environment of the commands it spawns from
+          # an allowlist (`basicEnvVars` in lib/util/exec/env.ts — CI, PATH,
+          # HOME, proxies, ...) plus customEnvVariables. A CARGO_* var declared
+          # as a step `env:` reaches the Renovate process but is stripped before
+          # cargo ever sees it. Nothing logs that it was dropped; the only symptom
+          # is cargo failing to parse the manifest.
+          RENOVATE_CUSTOM_ENV_VARIABLES: |
+            {
+              "CARGO_REGISTRIES_KELLNR_INDEX": "sparse+https://crates.ferrlabs.com/api/v1/crates/",
+              "CARGO_REGISTRIES_KELLNR_TOKEN": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
+            }
           # Identity Renovate must recognise as its own so it keeps
           # auto-rebasing its PRs instead of assuming a human edited them.
           # Must byte-match the author GitHub attributes to the App bot when


### PR DESCRIPTION
Remplace #163, qui traitait une cause racine incomplète et n'a pas corrigé le problème (vérifié sur un run : `registry index was not found` persiste).

## Ce que #163 a manqué

Il y a **deux** filtres d'environnement en série. #163 n'a réparé que le premier.

1. `renovatebot/github-action` filtre `process.env` avant de peupler le conteneur (`env-regex`) — réparé par #163.
2. **Renovate filtre son propre environnement avant de lancer cargo** — c'est ce qui bloquait.

Le second est visible dans `lib/util/exec/env.ts` : l'environnement des commandes lancées par Renovate est construit depuis une **allowlist**, pas hérité.

```js
export function getChildProcessEnv(customEnvVars = []) {
  const env = {};
  if (GlobalConfig.get('exposeAllEnv')) return { ...process.env };
  const envVars = [...basicEnvVars, ...customEnvVars];   // ← allowlist
  envVars.forEach((envVar) => {
    if (typeof process.env[envVar] !== 'undefined') env[envVar] = process.env[envVar];
  });
  ...
}
```

`basicEnvVars` est une liste en dur (`CI`, `PATH`, `HOME`, proxies, `SSL_CERT_*`…) qui ne contient aucun `CARGO_*`. Une variable déclarée en `env:` de step atteint donc le process Renovate mais est **retirée avant que cargo la voie**. Rien ne loggue qu'elle a été jetée — le seul symptôme est l'échec de parsing du manifeste, ce qui rend le diagnostic trompeur.

`getChildEnv` (`lib/util/exec/utils.ts`) montre la seule voie d'entrée :

```js
const globalConfigEnv = getCustomEnv();               // ← customEnvVariables
const parentEnv = getChildProcessEnv(inheritedKeys);  // ← allowlist ci-dessus
const combinedEnv = { ...extraEnv, ...parentEnv, ...globalConfigEnv, ... };
```

## Correctif

Déclarer le registre via `customEnvVariables` (`RENOVATE_CUSTOM_ENV_VARIABLES`), qui alimente `globalConfigEnv` et atteint donc cargo.

Ça rend l'`env-regex` de #163 **superflu, et pas seulement insuffisant** : `RENOVATE_CUSTOM_ENV_VARIABLES` porte le préfixe `RENOVATE_` et traverse nativement le filtre par défaut de l'action, avec les valeurs embarquées dans son JSON. L'override d'`env-regex` et les deux `CARGO_*` en `env:` nu sont donc retirés — le filtre par défaut de l'action redevient effectif.

Vérifié en local : YAML parsé, JSON valide après interpolation du secret, les deux clés attendues, et `RENOVATE_CUSTOM_ENV_VARIABLES` passe bien le regex par défaut de l'action.

## À confirmer après merge

Aucun check CI ne couvre ceci — la validation vient d'un run réel. Critère de succès : plus de `registry index was not found` dans les logs.

Si le token est mal câblé, une erreur **distincte** apparaîtra alors (401/403), l'auth du registre n'ayant jamais encore été exercée jusqu'ici.
