### PR TITLE
fix(renovate): declare the cargo credential provider for the private registry

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -202,10 +202,23 @@ jobs:
           # as a step `env:` reaches the Renovate process but is stripped before
           # cargo ever sees it. Nothing logs that it was dropped; the only symptom
           # is cargo failing to parse the manifest.
+          # These mirror api/.cargo/config.toml, which cargo does not read here:
+          # it looks for .cargo/config.toml upwards from the cwd, not from
+          # --manifest-path. Both of that file's halves must be replicated —
+          # the registry index *and* the credential provider.
+          #
+          # global-credential-providers only restates cargo's own default, but
+          # relying on the default is not equivalent to declaring it: cargo
+          # refuses any auth-required registry unless the provider is set
+          # explicitly (`!global_provider_defined` in util/auth/mod.rs), and
+          # fails with "authenticated registries require a credential-provider"
+          # even when the token is valid. Keep this in sync with
+          # api/.cargo/config.toml in the consuming repos.
           RENOVATE_CUSTOM_ENV_VARIABLES: |
             {
               "CARGO_REGISTRIES_KELLNR_INDEX": "sparse+https://crates.ferrlabs.com/api/v1/crates/",
-              "CARGO_REGISTRIES_KELLNR_TOKEN": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
+              "CARGO_REGISTRIES_KELLNR_TOKEN": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}",
+              "CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS": "cargo:token"
             }
           # Identity Renovate must recognise as its own so it keeps
           # auto-rebasing its PRs instead of assuming a human edited them.


### PR DESCRIPTION
Suite de #164. Le registre est désormais résolu (`Updating 'kellnr' index` dans les logs, plus aucun `registry index was not found`), mais `cargo update` échoue maintenant plus loin, sur une erreur distincte :

```
Caused by:
  unable to update registry `kellnr`
Caused by:
  authenticated registries require a credential-provider to be configured
```

## Cause

`api/.cargo/config.toml` des repos consommateurs contient **deux** morceaux :

```toml
[registries.kellnr]
index = "sparse+https://crates.ferrlabs.com/api/v1/crates/"   # ← répliqué par #164

[registry]
global-credential-providers = ["cargo:token"]                  # ← jamais répliqué
```

Renovate invoque cargo depuis la racine du repo, où ce fichier n'est pas découvert : cargo cherche `.cargo/config.toml` en remontant depuis le **cwd**, pas depuis `--manifest-path`. Les deux moitiés doivent donc être répliquées ; #164 n'en a répliqué qu'une.

Le piège est que `global-credential-providers` ne fait que **redire le défaut de cargo** — mais s'appuyer sur le défaut n'équivaut pas à le déclarer (`src/cargo/util/auth/mod.rs`) :

```rust
let mut global_provider_defined = true;
let default_providers = || {
    global_provider_defined = false;          // ← s'appuyer sur le défaut met ce flag à false
    vec![vec!["cargo:token".to_string()]]
};
let global_providers = gctx
    .get::<Option<Vec<Value<String>>>>("registry.global-credential-providers")?
    .filter(|p| !p.is_empty())
    .map(...)
    .unwrap_or_else(default_providers);
...
if !global_provider_defined && require_cred_provider_config {
    bail!("authenticated registries require a credential-provider to be configured...")
}
```

Pour un registre `auth-required`, cargo exige que le provider soit déclaré **explicitement**, et échoue sinon — même avec un token parfaitement valide. C'est un garde-fou délibéré, pas un bug.

## Correctif

Ajout de `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: "cargo:token"` à `customEnvVariables`.

Vérifié dans le code plutôt que dans la doc (qui ne précise pas le format des tableaux via env) : `get_env_list` dans `src/cargo/util/context/mod.rs` fait `env_val.split_whitespace()`, donc `"cargo:token"` donne bien `["cargo:token"]`. Le mapping clé → variable (`registry.global-credential-providers` → `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS`) suit la règle documentée : majuscules, points et tirets en underscores.

Validé en local : YAML parsé, JSON valide après interpolation du secret, valeurs identiques à `api/.cargo/config.toml`.

## À confirmer après merge

Aucun check CI ne couvre ceci. Critère de succès sur un run réel : plus aucune `artifactErrors` cargo. Si le token lui-même pose problème, l'erreur suivante sera un 401/403 — l'auth n'ayant encore jamais abouti jusqu'ici.
