### PR TITLE
fix(renovate): scope the dispatch app token to actions:write

### DIFF
--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -44,6 +44,7 @@ jobs:
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: FerrLabs
           repositories: .github
+          permission-actions: write
       - name: Trigger a repo-scoped Renovate run
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Closes #172

Narrows the Renovate App token minted for the instant-rebase dispatch to `permission-actions: write` on `.github` — the only permission `gh workflow run` needs. Silences the zizmor `github-app` code-scanning alert legitimately (least privilege, not a suppression comment), and fails fast with a clear error if the app lacks the permission.