### PR TITLE
ci: run go test/build on the medium runner pool

### DIFF
--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -8,7 +8,7 @@ on:
         type: string
         default: '.'
       runner:
-        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool, public repos use ubuntu-latest.'
         type: string
         default: ''
       go-version-file:
@@ -155,7 +155,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -244,7 +244,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-large' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -23,7 +23,7 @@ on:
         required: false
         default: ''
       runner:
-        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool, public repos use ubuntu-latest.'
         type: string
         required: false
         default: ''

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -49,7 +49,7 @@ on:
         required: false
         default: '--all-projects'
       runner:
-        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool, public repos use ubuntu-latest.'
         type: string
         required: false
         default: ''

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       runner:
-        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool (ferrlabs-k8s-large for build/test jobs), public repos use ubuntu-latest.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s pool, public repos use ubuntu-latest.'
         type: string
         default: ''
       working-directory:


### PR DESCRIPTION
Le pool `-large` est désormais réservé aux builds Rust (cargo est le seul workload qui exploite réellement ses 3 CPU). Le pool medium passe à 2 CPU / 6Gi côté k8s, donc les jobs go n'y perdent quasiment rien.

- `reusable-ci-go` : jobs `test` et `build` passent de `ferrlabs-k8s-large` à `ferrlabs-k8s`
- descriptions de l'input `runner` mises à jour là où elles mentionnaient encore le tier large à tort (node/astro/go/security-scan/sonarqube/release-rust n'y envoient plus rien)

`reusable-ci-rust` (`test` + `coverage`) reste sur `-large`, volontairement.