### PR TITLE
ci: cache docker build layers in the registry

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -56,6 +56,16 @@ on:
         type: boolean
         required: false
         default: true
+      cache:
+        description: 'Reuse a registry-side layer cache at `<image-name>-buildcache`. The ARC runners mount their container store on an emptyDir, so the local `--layers` cache dies with the pod and every build recompiles from scratch; keeping the cache in the registry is what makes it survive. A missing cache repo is a silent miss, so the first build just populates it. Set false for images whose layers are not worth caching.'
+        type: boolean
+        required: false
+        default: true
+      cache-ttl:
+        description: 'Ignore cached layers older than this (buildah --cache-ttl, e.g. 168h). Bounds how long a stale base image can be reused before a rebuild picks up upstream security updates.'
+        type: string
+        required: false
+        default: '168h'
       push-retries:
         description: 'How many times to retry each manifest push if the registry returns a transient error (5xx, network reset). Backoff is 10s, 30s, 90s, … capped at 5 min. Set to 1 to disable retries.'
         type: number
@@ -139,6 +149,8 @@ jobs:
           SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
           PACKAGES_READ: ${{ secrets.packages-read }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo-registry-token }}
+          CACHE: ${{ inputs.cache }}
+          CACHE_TTL: ${{ inputs.cache-ttl }}
         run: |
           set -euo pipefail
 
@@ -157,9 +169,31 @@ jobs:
             [ -n "$line" ] && build_arg_args+=(--build-arg "$line")
           done <<< "${BUILD_ARGS:-}"
 
+          # Registry-side layer cache. The runner's container store is an
+          # emptyDir on an ephemeral ARC pod, so `--layers` alone caches
+          # nothing across runs — a Rust image recompiles every dependency on
+          # every build. Pushing the layers to `<image>-buildcache` is what
+          # makes them outlive the pod.
+          #
+          # Only when the image lives on GHCR: that is the one registry the
+          # step above authenticated against, and --cache-to needs push rights.
+          # A missing cache repo is a silent miss (verified with buildah
+          # 1.33.7), so the first build simply populates it.
+          cache_args=()
+          if [ "$CACHE" = "true" ] && [ "${IMAGE#ghcr.io/}" != "$IMAGE" ]; then
+            CACHE_REPO="${IMAGE}-buildcache"
+            cache_args+=(--cache-from "$CACHE_REPO" --cache-ttl "$CACHE_TTL")
+            # Only publish the cache when we are publishing the image itself:
+            # a build that is not pushed (smoke-test-only) must not overwrite
+            # the cache other builds depend on.
+            [ "$PUSH" = "true" ] && cache_args+=(--cache-to "$CACHE_REPO")
+            echo "Layer cache: $CACHE_REPO (ttl $CACHE_TTL, publish=$PUSH)"
+          fi
+
           buildah build \
             --isolation=chroot --layers \
             --platform "$PLATFORMS" \
+            "${cache_args[@]}" \
             "${secret_args[@]}" "${build_arg_args[@]}" \
             --manifest "$IMAGE:$TAG" \
             -f "$CONTEXT/$DOCKERFILE" "$CONTEXT"


### PR DESCRIPTION
Les images sont actuellement reconstruites intégralement à chaque build : `buildah build --layers` alimente bien un cache de layers, mais le store des runners ARC est monté sur un `emptyDir` (`sizeLimit: 8Gi`), donc il meurt avec le pod éphémère. Concrètement, chaque image Rust (`api`, `bff`, `admin-api`, `runner`) recompile toutes ses dépendances à chaque release, et chaque image front refait un `pnpm install` complet.

Il n'y avait ni `--cache-from`/`--cache-to`, ni `--mount=type=cache` dans les Dockerfiles. Le sccache sur Garage existe mais n'est câblé que dans `reusable-ci-rust` — il ne couvre pas la compilation qui a lieu *dans* le conteneur.

Ce PR pousse le cache de layers dans le registre, à `<image-name>-buildcache`, ce qui est la seule forme de cache qui survit à un runner éphémère.

**Détails**
- Nouveaux inputs `cache` (défaut `true`) et `cache-ttl` (défaut `168h`).
- Actif uniquement pour les images GHCR : c'est le seul registre auprès duquel l'étape précédente s'authentifie, et `--cache-to` exige les droits de push.
- `--cache-to` n'est ajouté que si `push=true`, pour qu'un build en smoke-test-only n'écrase pas le cache dont dépendent les autres.
- Le `cache-ttl` borne la réutilisation d'une base périmée, pour que les mises à jour de sécurité amont finissent par être reprises.

**Vérifications**
- `buildah 1.33.7` sur les runners supporte `--cache-from`/`--cache-to`/`--cache-ttl` (vérifié dans un pod runner).
- Un `--cache-from` sur un dépôt de cache inexistant est un miss silencieux, pas une erreur (testé sur un runner : build `EXIT=0`) — le premier build se contente donc de peupler le cache.
- Les 4 combinaisons de la logique conditionnelle (cache on/off, push on/off, registre non-GHCR) ont été simulées.

Le gain réel se mesurera au premier build suivant : la première release peuple le cache, la suivante devrait le réutiliser.