### PR TITLE
feat(docker): passer les identifiants sccache aux builds d'image

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -87,6 +87,12 @@ on:
       cargo-registry-token:
         description: 'Token for the private cargo registry (Kellnr), for builds that fetch registry-based Kit crates in addition to git-based ones. Exposed to BuildKit as a secret (id=cargo-registry-token), same handling as packages-read. In the Dockerfile: RUN --mount=type=secret,id=cargo-registry-token sh -c ''CARGO_REGISTRIES_KELLNR_TOKEN="$(cat /run/secrets/cargo-registry-token)" cargo build ...''.'
         required: false
+      sccache-s3-key:
+        description: 'garage S3 access key (SCCACHE_S3_KEY) for a compiled-artifact cache INSIDE the image build. The registry layer cache only helps while the layer inputs are unchanged, and a release bumps the version line in Cargo.toml — which is an input of the layer that caches the dependency compile, so every release recompiles every dependency from scratch. sccache caches each crate individually and survives that. Exposed as a build secret (id=sccache-s3-key); the Dockerfile must degrade gracefully when it is absent.'
+        required: false
+      sccache-s3-secret:
+        description: 'garage S3 secret key (SCCACHE_S3_SECRET). Pair of sccache-s3-key; both must be set for the cache to be wired in.'
+        required: false
 
 permissions:
   contents: read
@@ -149,6 +155,8 @@ jobs:
           SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
           PACKAGES_READ: ${{ secrets.packages-read }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo-registry-token }}
+          SCCACHE_S3_KEY: ${{ secrets.sccache-s3-key }}
+          SCCACHE_S3_SECRET: ${{ secrets.sccache-s3-secret }}
           CACHE: ${{ inputs.cache }}
           CACHE_TTL: ${{ inputs.cache-ttl }}
         run: |
@@ -162,6 +170,17 @@ jobs:
           if [ -n "${CARGO_REGISTRY_TOKEN:-}" ]; then
             printf '%s' "$CARGO_REGISTRY_TOKEN" > "$RUNNER_TEMP/cargo-registry-token"
             secret_args+=(--secret "id=cargo-registry-token,src=$RUNNER_TEMP/cargo-registry-token")
+          fi
+          # Compiled-artifact cache for Rust image builds. Both halves or
+          # neither: a key without its secret would have the Dockerfile wire up
+          # sccache against credentials that cannot authenticate, turning a
+          # cache miss into a build failure.
+          if [ -n "${SCCACHE_S3_KEY:-}" ] && [ -n "${SCCACHE_S3_SECRET:-}" ]; then
+            printf '%s' "$SCCACHE_S3_KEY" > "$RUNNER_TEMP/sccache-s3-key"
+            printf '%s' "$SCCACHE_S3_SECRET" > "$RUNNER_TEMP/sccache-s3-secret"
+            secret_args+=(--secret "id=sccache-s3-key,src=$RUNNER_TEMP/sccache-s3-key")
+            secret_args+=(--secret "id=sccache-s3-secret,src=$RUNNER_TEMP/sccache-s3-secret")
+            echo "sccache credentials passed to the build"
           fi
 
           build_arg_args=()


### PR DESCRIPTION
Les images Rust recompilent **toutes** leurs dépendances à chaque release. Diagnostic sur le build de l'API FerrFleet :

```
STEP 2  WORKDIR                              --> Using cache
STEP 3  apt-get install                      --> Using cache
STEP 4  ENV                                  --> Using cache
STEP 5  COPY api/Cargo.toml api/Cargo.lock   (aucun cache)
STEP 10 cargo build (dépendances)            Compiling serde… ~10 min
```

Le cache de couches côté registre fonctionne — il touche jusqu'à l'étape 4 — puis casse à l'étape 5, parce que le commit de release bump la ligne `version` de `api/Cargo.toml`, qui est une entrée de la couche mettant en cache la compilation des dépendances. Une couche invalidée invalide toutes ses descendantes, donc ~10 minutes à recompiler des crates tierces qui n'ont pas bougé. Mesuré : 15 à 21 minutes par image.

Détail qui rend la chose absurde : le commit de release ne touche **pas** `Cargo.lock`. Le seul fichier qui casse le cache est celui dont le changement ne change rien à ce qui doit être compilé.

## Ce que fait cette PR

Deux secrets optionnels, `sccache-s3-key` et `sccache-s3-secret`, exposés au build comme secrets BuildKit. Le cache par couches ne suffit pas ici par construction ; sccache, lui, indexe chaque compilation individuellement et survit à un bump de version.

C'est le même backend garage S3 que `reusable-ci-rust` utilise déjà — pas de nouvelle infrastructure, et le cache est partagé avec la CI de PR.

**Les deux moitiés ou aucune** : une clé sans son secret ferait câbler sccache contre des identifiants qui ne peuvent pas s'authentifier, transformant un défaut de cache en échec de build.

**Aucun changement de comportement pour les appelants existants.** Les secrets sont optionnels ; un repo qui ne les passe pas voit exactement le build d'aujourd'hui. Côté Dockerfile, un `--mount=type=secret` absent laisse simplement le fichier manquant, ce qui doit être traité comme « pas de cache » et non comme une erreur.

## Vérifié

- Le YAML se charge (`yaml.safe_load`).
- Les builds tournent avec `--isolation=chroot`, donc les `RUN` partagent le réseau du pod runner : `garage.ferrlabs.svc.cluster.local:3900` est joignable depuis l'intérieur du build. C'est la prémisse de tout le dispositif.

## Non vérifié

**Aucun build réel n'a encore tourné avec ces secrets.** La preuve se fera sur FerrFleet-Cloud, en pilote, avant de câbler les quatre autres repos (FerrLabs, FerrVault, FerrTrack, FerrGrowth). Je ne voulais pas modifier cinq pipelines d'image sur une hypothèse non testée.