### PR TITLE
docs(ci): interdit le routage par group pour le job integration

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -230,6 +230,13 @@ jobs:
       PGHOST: ${{ inputs.integration-db-host }}
       PGPORT: ${{ inputs.integration-db-port }}
       PGUSER: ${{ inputs.integration-db-user }}
+    # NE JAMAIS basculer ce job sur `group=ferrlabs-k8s`. Il parle a
+    # postgres-ci.github-runner.svc.cluster.local, un service INTERNE au cluster
+    # de production. Le runner group contient aussi le site Homelab, d'ou ce
+    # service est injoignable : le job y echouerait sur une resolution DNS, sans
+    # rapport apparent avec la base. Cibler le scale set par son NOM reste
+    # possible meme s'il appartient a un group -- c'est exactement ce qu'on fait
+    # ici, et il faut le conserver.
     runs-on: ${{ inputs.integration-runner != '' && inputs.integration-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:


### PR DESCRIPTION
Prérequis à l'arrivée des runners Homelab dans le runner group `ferrlabs-k8s` (FerrLabs/Homelab#53).

## Constat : rien à épingler

Le plan prévoyait d'épingler les jobs à dépendance cluster sur le nom du scale set. **C'est déjà le cas partout** : aucun workflow de ce repo n'utilise la syntaxe `group=`, tous ciblent `ferrlabs-k8s` par son nom. GitHub ne peut donc router aucun job vers le Homelab tant qu'une bascule explicite n'a pas eu lieu.

Aucun changement de comportement ici, et aucun délai de propagation Renovate à attendre.

## Ce que cette PR ajoute

Une garde en commentaire sur le seul job réellement lié au cluster de production : `integration` parle à `postgres-ci.github-runner.svc.cluster.local`, injoignable depuis le Homelab.

Le piège mérite d'être écrit : basculé sur `group=`, ce job échouerait sur une **résolution DNS**, sans rapport apparent avec la base de données — et seulement quand GitHub choisirait le Homelab, donc de façon intermittente.

Cibler un scale set par son nom reste possible même lorsqu'il appartient à un group : c'est ce qu'on fait, et il faut le conserver.