### PR TITLE
ci: route les jobs vers le runner group ferrlabs-k8s

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -104,7 +104,7 @@ jobs:
     name: Build & Check
     # medium (was -large): astro/vite build fits on 1 CPU / 3Gi and this frees
     # the scarce 2-slot -large tier for the heavy Rust build/test/coverage jobs.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -144,7 +144,7 @@ jobs:
   i18n:
     name: i18n parity
     if: inputs.enable-i18n
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -172,7 +172,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
Bascule les workflows réutilisables du **nom** du scale set de production vers le **runner group** `ferrlabs-k8s`, qui réunit le site de production et celui du Homelab (FerrLabs/Homelab#47).

Jusqu'ici tout ciblait `ferrlabs-k8s` par son nom : les deux slots du Homelab existaient sans jamais recevoir un seul job.

## Portée

**31 occurrences basculées** dans 11 workflows :

```
reusable-security-scan     6      reusable-ferrflow-release  3
reusable-ci-go             5      reusable-ci-astro          3
reusable-docker-build      4      reusable-ci-node           2
reusable-ci-rust           3      reusable-release-rust      2
reusable-sbom-track        1      reusable-sonarqube-scan    1
reusable-renovate-dispatch 1 (valeur par défaut de l'input `runner`)
```

## Une seule exception, volontaire

Le job `integration` de `reusable-ci-rust` **reste ciblé par nom** :

```yaml
runs-on: ${{ ... 'ferrlabs-k8s' ... }}   # ligne 240, inchangée
```

Il parle à `postgres-ci.github-runner.svc.cluster.local`, interne au cluster de production. Routé par group, il échouerait sur une **résolution DNS** — sans rapport apparent avec la base, et seulement quand GitHub choisirait le Homelab, donc de façon intermittente. La garde ajoutée en #186 est juste au-dessus de cette ligne.

## Non touchés

`ferrlabs-k8s-large` et `ferrlabs-k8s-light` gardent leur ciblage par nom : ce sont des **tiers**, pas des sites. Les mettre dans un group laisserait un job lourd atterrir sur un runner `light` (0,5 CPU, 512 Mi, sans buildah), et un job trivial monopoliser le tier le plus rare.

## Vérifié avant bascule

Tous les services appelés par ces workflows sont publics, donc joignables depuis le Homelab :

```
crates.ferrlabs.com · dtrack.ferrlabs.com · sonar.ferrlabs.com
```

`postgres-ci` est la seule dépendance in-cluster du dépôt — d'où l'unique exception ci-dessus.

Les 14 workflows passent la validation YAML.

## Différences du site Homelab à surveiller

- **pas de miroir de registre** : le namespace `registry` n'existe que sur la production, les pulls partent vers l'amont (premier tirage plus lent, pas d'échec attendu) ;
- **connexion résidentielle** : débit et latence inférieurs ;
- **limites identiques** au tier medium de production (2 CPU, 6 Gi, 10 Gi éphémère) — c'est la condition de l'interchangeabilité.

## Propagation et retour arrière

⚠️ Les dépôts épinglent les réutilisables **par SHA**, et c'est Renovate qui les bump, toutes les 6 h. La bascule ne prend donc effet que progressivement, dépôt par dépôt — ce qui donne une fenêtre d'observation naturelle.

En cas de problème : revert de cette PR. Les jobs repartent sur la production, sans manipulation côté cluster.
