### PR TITLE
ci(sast): add FerrLabs OpenGrep ruleset from the org audit

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -13,6 +13,16 @@ on:
         type: string
         required: false
         default: ''
+      ferrlabs-rules:
+        description: 'Also scan with the FerrLabs ruleset (sast/ferrlabs.yml in FerrLabs/.github), on top of whatever sast-config resolves to. Rules encode recurring defects found in our own code, so this is on by default.'
+        type: boolean
+        required: false
+        default: true
+      ferrlabs-rules-ref:
+        description: 'Git ref of FerrLabs/.github to pull the ruleset from. Pin to a SHA to freeze the rules for a repo.'
+        type: string
+        required: false
+        default: 'main'
       osv-scan-args:
         description: 'Extra args for osv-scanner'
         type: string
@@ -185,13 +195,38 @@ jobs:
             git clone --depth 1 https://github.com/opengrep/opengrep-rules.git "$RUNNER_TEMP/opengrep-rules"
             echo "path=$RUNNER_TEMP/opengrep-rules" >> "$GITHUB_OUTPUT"
           fi
+      - name: Fetch the FerrLabs ruleset
+        id: ferrlabs-rules
+        if: ${{ inputs.ferrlabs-rules }}
+        env:
+          REF: ${{ inputs.ferrlabs-rules-ref }}
+        run: |
+          set -euo pipefail
+          # Downloaded into RUNNER_TEMP, not the workspace, so the rules file
+          # is not itself part of the tree being scanned.
+          DEST="$RUNNER_TEMP/ferrlabs-sast.yml"
+          URL="https://raw.githubusercontent.com/FerrLabs/.github/${REF}/sast/ferrlabs.yml"
+          if curl -fsSL "$URL" -o "$DEST"; then
+            echo "path=$DEST" >> "$GITHUB_OUTPUT"
+            echo "Loaded FerrLabs ruleset from $REF"
+          else
+            # Never fail the security scan because our own rules are
+            # unreachable — the community set still runs.
+            echo "::warning::Could not fetch the FerrLabs ruleset from $URL — scanning without it."
+          fi
       - name: Run OpenGrep
         run: |
           set +e
+          FERRLABS_RULES="${{ steps.ferrlabs-rules.outputs.path }}"
+          EXTRA=()
+          if [ -n "$FERRLABS_RULES" ]; then
+            EXTRA+=(-f "$FERRLABS_RULES")
+          fi
           opengrep scan \
             --sarif-output=opengrep.sarif \
             --error \
             -f "${{ steps.rules.outputs.path }}" \
+            "${EXTRA[@]}" \
             .
           EXIT=$?
           set -e

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -215,9 +215,10 @@ jobs:
             echo "::warning::Could not fetch the FerrLabs ruleset from $URL — scanning without it."
           fi
       - name: Run OpenGrep
+        env:
+          FERRLABS_RULES: ${{ steps.ferrlabs-rules.outputs.path }}
         run: |
           set +e
-          FERRLABS_RULES="${{ steps.ferrlabs-rules.outputs.path }}"
           EXTRA=()
           if [ -n "$FERRLABS_RULES" ]; then
             EXTRA+=(-f "$FERRLABS_RULES")

--- a/sast/ferrlabs.yml
+++ b/sast/ferrlabs.yml
@@ -1,114 +1,86 @@
 rules:
-  - id: ferrlabs-native-browser-dialog
-    languages: [typescript, javascript]
-    severity: ERROR
-    message: >-
-      Native browser dialog. These render the unstyled system dialog, are not
-      themeable, block the event loop and cannot be driven in tests. Use the
-      shared Modal/Dialog from @ferrlabs/ui-ng, or Toast for non-blocking
-      feedback.
-    patterns:
-      - pattern-either:
-          - pattern: window.alert(...)
-          - pattern: window.confirm(...)
-          - pattern: window.prompt(...)
-    paths:
-      exclude:
-        - "*.stories.tsx"
-        - "*.stories.ts"
-        - "*.spec.ts"
-        - "*.test.ts"
-        - "**/dist/**"
-        - "**/docs/design-bundle/**"
+- id: ferrlabs-native-browser-dialog
+  languages:
+  - typescript
+  - javascript
+  severity: ERROR
+  message: Native browser dialog. These render the unstyled system dialog, are not themeable, block the
+    event loop and cannot be driven in tests. Use the shared Modal/Dialog from @ferrlabs/ui-ng, or Toast
+    for non-blocking feedback.
+  patterns:
+  - pattern-either:
+    - pattern: window.alert(...)
+    - pattern: window.confirm(...)
+    - pattern: window.prompt(...)
+  paths:
+    exclude:
+    - '*.stories.tsx'
+    - '*.stories.ts'
+    - '*.spec.ts'
+    - '*.test.ts'
+    - '**/dist/**'
+    - '**/docs/design-bundle/**'
+- id: ferrlabs-stringly-typed-domain
+  languages:
+  - rust
+  severity: WARNING
+  message: 'Closed domain set validated by matching string literals. Model this as an enum with #[derive(sqlx::Type,
+    Deserialize)] and #[sqlx(type_name=...)] so serde rejects invalid input at deserialization and the
+    compiler enforces exhaustiveness. Hand-written validators drift from the database type they mirror.'
+  patterns:
+  - pattern-regex: match\s+\w+\s*\{\s*"[a-z_]+"\s*\|\s*"[a-z_]+"\s*(\|\s*"[a-z_]+"\s*)*=>
+  paths:
+    exclude:
+    - '**/tests/**'
+    - '**/migrations/**'
+- id: ferrlabs-jwt-validation-without-issuer
+  languages:
+  - rust
+  severity: WARNING
+  message: JWT decoded with a bare Validation — signature and exp only, no issuer or audience binding.
+    Add set_issuer / set_audience / set_required_spec_claims so a token minted for another purpose cannot
+    be replayed as a session.
+  patterns:
+  - pattern-either:
+    - pattern: decode::<$T>($TOK, $KEY, &Validation::default())
+    - pattern: decode::<$T>($TOK, $KEY, &Validation::new($ALG))
+  paths:
+    exclude:
+    - '**/tests/**'
+- id: ferrlabs-unbounded-public-query
+  languages:
+  - rust
+  severity: WARNING
+  message: fetch_all on an unauthenticated route with no LIMIT. A small request can force an arbitrarily
+    large response and scan. Cap the query and paginate.
+  patterns:
+  - pattern: $Q.fetch_all(...)
+  - pattern-not-inside: '$S = "...LIMIT...";
 
-  - id: ferrlabs-login-timing-oracle
-    languages: [rust]
-    severity: WARNING
-    message: >-
-      Login handler returns before verifying a password when the account is
-      absent. The unknown-account path answers in microseconds while a known
-      account pays the full hash cost, which turns the endpoint into an
-      account-existence oracle. Verify against a dummy hash on the absent
-      path so both branches take the same time (see FerrGames
-      `auth::password::dummy_hash`).
-    patterns:
-      - pattern-inside: |
-          async fn $LOGIN(...) -> $RET { ... }
-      - pattern: |
-          let $SOME_ROW = $ROW else { return Err(...); };
-          ...
-          $OK = verify_password(...);
-    paths:
-      exclude:
-        - "**/tests/**"
+      ...
 
-  - id: ferrlabs-stringly-typed-domain
-    languages: [rust]
-    severity: WARNING
-    message: >-
-      Closed domain set validated by matching string literals. Model this as an
-      enum with #[derive(sqlx::Type, Deserialize)] and #[sqlx(type_name=...)]
-      so serde rejects invalid input at deserialization and the compiler
-      enforces exhaustiveness. Hand-written validators drift from the database
-      type they mirror.
-    patterns:
-      - pattern-regex: 'match\s+\w+\s*\{\s*"[a-z_]+"\s*\|\s*"[a-z_]+"\s*(\|\s*"[a-z_]+"\s*)*=>'
-    paths:
-      exclude:
-        - "**/tests/**"
-        - "**/migrations/**"
-
-  - id: ferrlabs-jwt-validation-without-issuer
-    languages: [rust]
-    severity: WARNING
-    message: >-
-      JWT decoded with a bare Validation — signature and exp only, no issuer or
-      audience binding. Add set_issuer / set_audience / set_required_spec_claims
-      so a token minted for another purpose cannot be replayed as a session.
-    patterns:
-      - pattern-either:
-          - pattern: decode::<$T>($TOK, $KEY, &Validation::default())
-          - pattern: decode::<$T>($TOK, $KEY, &Validation::new($ALG))
-    paths:
-      exclude:
-        - "**/tests/**"
-
-  - id: ferrlabs-unbounded-public-query
-    languages: [rust]
-    severity: WARNING
-    message: >-
-      fetch_all on an unauthenticated route with no LIMIT. A small request can
-      force an arbitrarily large response and scan. Cap the query and paginate.
-    patterns:
-      - pattern: $Q.fetch_all(...)
-      - pattern-not-inside: |
-          $S = "...LIMIT...";
-          ...
-    paths:
-      include:
-        - "**/routes/public*.rs"
-
-  - id: ferrlabs-hardcoded-plan-limit
-    languages: [rust]
-    severity: WARNING
-    message: >-
-      Plan limit returned as a constant. Look the tier up through
-      ferrlabs-billing — a hardcoded cap gives paid features to free orgs and
-      caps the tiers that paid to remove the limit.
-    patterns:
-      - pattern-regex: 'fn\s+\w*(cap|limit)_for_plan\w*\([^)]*\)\s*->\s*[^{]+\{\s*(Some\()?\d+'
-
-  - id: ferrlabs-local-ui-primitive
-    languages: [typescript]
-    severity: WARNING
-    message: >-
-      Component selector duplicates a primitive shipped by @ferrlabs/ui-ng
-      (card, page-header, modal, button, input, badge/tag, empty, error).
-      Consume the shared component; if a variant is missing, add it to the
-      library rather than forking it locally — private copies drift.
-    patterns:
-      - pattern-regex: "selector:\\s*'[a-z]+-(card|page-header|modal|button|input|badge|pill|empty|error|pagination)'"
-    paths:
-      exclude:
-        - "**/dist/**"
-        - "**/node_modules/**"
+      '
+  paths:
+    include:
+    - '**/routes/public*.rs'
+- id: ferrlabs-hardcoded-plan-limit
+  languages:
+  - rust
+  severity: WARNING
+  message: Plan limit returned as a constant. Look the tier up through ferrlabs-billing — a hardcoded
+    cap gives paid features to free orgs and caps the tiers that paid to remove the limit.
+  patterns:
+  - pattern-regex: fn\s+\w*(cap|limit)_for_plan\w*\([^)]*\)\s*->\s*[^{]+\{\s*(Some\()?\d+
+- id: ferrlabs-local-ui-primitive
+  languages:
+  - typescript
+  severity: WARNING
+  message: Component selector duplicates a primitive shipped by @ferrlabs/ui-ng (card, page-header, modal,
+    button, input, badge/tag, empty, error). Consume the shared component; if a variant is missing, add
+    it to the library rather than forking it locally — private copies drift.
+  patterns:
+  - pattern-regex: selector:\s*'[a-z]+-(card|page-header|modal|button|input|badge|pill|empty|error|pagination)'
+  paths:
+    exclude:
+    - '**/dist/**'
+    - '**/node_modules/**'

--- a/sast/ferrlabs.yml
+++ b/sast/ferrlabs.yml
@@ -1,0 +1,114 @@
+rules:
+  - id: ferrlabs-native-browser-dialog
+    languages: [typescript, javascript]
+    severity: ERROR
+    message: >-
+      Native browser dialog. These render the unstyled system dialog, are not
+      themeable, block the event loop and cannot be driven in tests. Use the
+      shared Modal/Dialog from @ferrlabs/ui-ng, or Toast for non-blocking
+      feedback.
+    patterns:
+      - pattern-either:
+          - pattern: window.alert(...)
+          - pattern: window.confirm(...)
+          - pattern: window.prompt(...)
+    paths:
+      exclude:
+        - "*.stories.tsx"
+        - "*.stories.ts"
+        - "*.spec.ts"
+        - "*.test.ts"
+        - "**/dist/**"
+        - "**/docs/design-bundle/**"
+
+  - id: ferrlabs-login-timing-oracle
+    languages: [rust]
+    severity: WARNING
+    message: >-
+      Login handler returns before verifying a password when the account is
+      absent. The unknown-account path answers in microseconds while a known
+      account pays the full hash cost, which turns the endpoint into an
+      account-existence oracle. Verify against a dummy hash on the absent
+      path so both branches take the same time (see FerrGames
+      `auth::password::dummy_hash`).
+    patterns:
+      - pattern-inside: |
+          async fn $LOGIN(...) -> $RET { ... }
+      - pattern: |
+          let $SOME_ROW = $ROW else { return Err(...); };
+          ...
+          $OK = verify_password(...);
+    paths:
+      exclude:
+        - "**/tests/**"
+
+  - id: ferrlabs-stringly-typed-domain
+    languages: [rust]
+    severity: WARNING
+    message: >-
+      Closed domain set validated by matching string literals. Model this as an
+      enum with #[derive(sqlx::Type, Deserialize)] and #[sqlx(type_name=...)]
+      so serde rejects invalid input at deserialization and the compiler
+      enforces exhaustiveness. Hand-written validators drift from the database
+      type they mirror.
+    patterns:
+      - pattern-regex: 'match\s+\w+\s*\{\s*"[a-z_]+"\s*\|\s*"[a-z_]+"\s*(\|\s*"[a-z_]+"\s*)*=>'
+    paths:
+      exclude:
+        - "**/tests/**"
+        - "**/migrations/**"
+
+  - id: ferrlabs-jwt-validation-without-issuer
+    languages: [rust]
+    severity: WARNING
+    message: >-
+      JWT decoded with a bare Validation — signature and exp only, no issuer or
+      audience binding. Add set_issuer / set_audience / set_required_spec_claims
+      so a token minted for another purpose cannot be replayed as a session.
+    patterns:
+      - pattern-either:
+          - pattern: decode::<$T>($TOK, $KEY, &Validation::default())
+          - pattern: decode::<$T>($TOK, $KEY, &Validation::new($ALG))
+    paths:
+      exclude:
+        - "**/tests/**"
+
+  - id: ferrlabs-unbounded-public-query
+    languages: [rust]
+    severity: WARNING
+    message: >-
+      fetch_all on an unauthenticated route with no LIMIT. A small request can
+      force an arbitrarily large response and scan. Cap the query and paginate.
+    patterns:
+      - pattern: $Q.fetch_all(...)
+      - pattern-not-inside: |
+          $S = "...LIMIT...";
+          ...
+    paths:
+      include:
+        - "**/routes/public*.rs"
+
+  - id: ferrlabs-hardcoded-plan-limit
+    languages: [rust]
+    severity: WARNING
+    message: >-
+      Plan limit returned as a constant. Look the tier up through
+      ferrlabs-billing — a hardcoded cap gives paid features to free orgs and
+      caps the tiers that paid to remove the limit.
+    patterns:
+      - pattern-regex: 'fn\s+\w*(cap|limit)_for_plan\w*\([^)]*\)\s*->\s*[^{]+\{\s*(Some\()?\d+'
+
+  - id: ferrlabs-local-ui-primitive
+    languages: [typescript]
+    severity: WARNING
+    message: >-
+      Component selector duplicates a primitive shipped by @ferrlabs/ui-ng
+      (card, page-header, modal, button, input, badge/tag, empty, error).
+      Consume the shared component; if a variant is missing, add it to the
+      library rather than forking it locally — private copies drift.
+    patterns:
+      - pattern-regex: "selector:\\s*'[a-z]+-(card|page-header|modal|button|input|badge|pill|empty|error|pagination)'"
+    paths:
+      exclude:
+        - "**/dist/**"
+        - "**/node_modules/**"


### PR DESCRIPTION
Closes #189

Adds a FerrLabs OpenGrep ruleset and wires it into the shared security scan, so the patterns the org audit found are checked on every push instead of once.

## Two parts

**1. `sast/ferrlabs.yml`** — six rules, each encoding a defect that recurred in more than one repo:

| Rule | From |
|---|---|
| `native-browser-dialog` | CLAUDE.md hard rule — org is currently clean, this keeps it that way |
| `stringly-typed-domain` | FerrTrack-Cloud#519, Status#137 |
| `jwt-validation-without-issuer` | FerrLabs-Cloud#721 |
| `unbounded-public-query` | FerrTrack-Cloud#520 |
| `hardcoded-plan-limit` | FerrTrack-Cloud#522 |
| `local-ui-primitive` | UI#333 + its four consumer issues |

**2. `reusable-security-scan.yml`** applies it by default. **19 repos already call this workflow**, so they all pick the rules up with no change on their side — the ruleset is passed as a second `-f` alongside whatever `sast-config` resolves to, rather than replacing it.

Two new inputs:
- `ferrlabs-rules` (default `true`) — opt out per repo
- `ferrlabs-rules-ref` (default `main`) — pin to a SHA to freeze the rules for a repo

The ruleset is fetched into `$RUNNER_TEMP`, not the workspace, so it is not itself part of the scanned tree. If the fetch fails the step warns and the scan continues on the community set — our own rules being unreachable must never break a security scan.

## Verified by running the engine

`semgrep` (OpenGrep is a fork of it, same rule format) was installed locally and every rule was executed against purpose-built fixtures.

Config parses: `found 0 configuration error(s), and 6 rule(s)`.

Positive cases — each fires at the right file and line:

```
ferrlabs-native-browser-dialog          bad-dialog.ts:2   (window.confirm)
ferrlabs-native-browser-dialog          bad-dialog.ts:3   (window.alert)
ferrlabs-jwt-validation-without-issuer  jwt.rs:2          (Validation::default())
ferrlabs-unbounded-public-query         public.rs:2       (fetch_all, no LIMIT)
```

Negative controls — **no findings**, as intended:

```
good.ts          this.modal.confirm({...})   → not flagged
login_fixed.rs   dummy_hash() constant-time  → not flagged
```

The three regex rules were separately run against the real files they were derived from: `stringly-typed` found 4 in `FerrTrack/models.rs`, `hardcoded-plan-limit` found 1 in `FerrTrack/rules.rs`, `local-ui-primitive` found 5 in `FerrVault/editorial.ts`.

## One rule was written, tested, and removed

`login-timing-oracle` (for FerrGrowth-Cloud#599) is **not** in this PR. It matched the vulnerable login *and* a correctly-fixed one using `dummy_hash` — the `let ... else` + `...` sequence pattern is too loose to distinguish them. A rule that flags correct code trains people to ignore the scanner, so it is better absent until it can be written precisely. #599 still tracks the underlying issue.

## Rollout note

`fail-on-sast` stays `false` by default, so this is advisory on merge — findings land in the Security tab, nothing blocks. Measure the noise before gating.

Expect `local-ui-primitive` to need tuning: FerrGames' `fg-game-card` is a legitimate product component that matches the pattern and is not a duplication of anything shared.
