### PR TITLE
ci: route les réutilisables restants vers le runner group

### DIFF
--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -92,7 +92,7 @@ permissions:
 jobs:
   detect:
     name: Detect Go module
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -117,7 +117,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -155,7 +155,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -208,7 +208,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -244,7 +244,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -136,7 +136,7 @@ jobs:
     name: Test & Build
     # medium (was -large): the node/vite build fits on 1 CPU / 3Gi and this
     # frees the scarce 2-slot -large tier for the heavy Rust jobs.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -217,7 +217,7 @@ jobs:
   quality:
     name: Quality (knip, madge, audit)
     if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -335,7 +335,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -396,7 +396,7 @@ jobs:
   typos:
     name: Typos
     if: inputs.enable-typos
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: crate-ci/typos@3bc303c295c081add5df4a4d52a1e117f2fb2dce # master

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -107,7 +107,7 @@ jobs:
     # hadolint via its static binary (not the hadolint-action Docker container)
     # so it runs on the self-hosted pool for private repos — the ARC runners
     # have buildah but no Docker daemon. Public repos fall back to ubuntu-latest.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Lint Dockerfile (hadolint)
@@ -271,7 +271,7 @@ jobs:
     # medium, not inputs.runner (-large): Trivy just pulls the pushed image
     # from the registry and scans it — no buildah/compile, so it doesn't need
     # the scarce 2-slot large tier. Frees a large slot per docker-build run.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       # Trivy reads ~/.docker/config.json to pull the image; without this a
       # private GHCR image fails with a 401/manifest-unknown.
@@ -324,7 +324,7 @@ jobs:
     # self-hosted pool for private repos. Public repos fall back to ubuntu-latest.
     # Keyless signing uses the Actions OIDC token, which is available on
     # self-hosted runners too (needs id-token: write, already granted).
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       - name: Install cosign
         run: |
@@ -363,7 +363,7 @@ jobs:
     if: inputs.push
     # medium, not inputs.runner (-large): Syft pulls the pushed image and
     # generates the SBOM — no buildah/compile, so no need for the large tier.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       # Syft pulls the image via the Docker keychain (~/.docker/config.json);
       # a private GHCR image needs this login or the scan fails to fetch it.

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -59,7 +59,7 @@ jobs:
   release:
     name: Release with FerrFlow
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -89,7 +89,7 @@ jobs:
     # publish` is idempotent against the registry, so re-running publishes only
     # what's tagged-but-missing (recovers the index-lag / partial-publish case).
     if: ${{ inputs.deferred-publish && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -115,7 +115,7 @@ jobs:
     name: Trigger Renovate scan on consumers
     needs: release
     if: ${{ inputs.trigger-renovate && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - name: Dispatch Renovate workflow
         env:

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -109,7 +109,7 @@ jobs:
   upload:
     name: Attest + upload assets
     needs: build
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -133,7 +133,7 @@ jobs:
     name: Publish crates.io
     needs: upload
     if: inputs.crate-publish
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -24,7 +24,7 @@ on:
       runner:
         description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
         type: string
-        default: 'ferrlabs-k8s'
+        default: 'group=ferrlabs-k8s'
 
 permissions: {}
 

--- a/.github/workflows/reusable-sbom-track.yml
+++ b/.github/workflows/reusable-sbom-track.yml
@@ -54,7 +54,7 @@ permissions:
 jobs:
   sbom:
     name: SBOM → Dependency-Track
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -108,7 +108,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -159,7 +159,7 @@ jobs:
 
   opengrep:
     name: opengrep (SAST)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -218,7 +218,7 @@ jobs:
 
   zizmor:
     name: zizmor (GitHub Actions security)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -259,7 +259,7 @@ jobs:
 
   trufflehog:
     name: trufflehog (secrets, deep history)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (!github.event.repository.private || inputs.run-on-private) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -297,7 +297,7 @@ jobs:
 
   snyk:
     name: snyk (deps)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -53,7 +53,7 @@ permissions:
 jobs:
   sonarqube:
     name: SonarQube analysis
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Bascule les workflows réutilisables du **nom** du scale set de production vers le **runner group** `ferrlabs-k8s`, qui réunit le site de production et celui du Homelab (FerrLabs/Homelab#47).

Jusqu'ici tout ciblait `ferrlabs-k8s` par son nom : les deux slots du Homelab existaient sans jamais recevoir un seul job.

## Portée

**31 occurrences basculées** dans 11 workflows :

```
reusable-security-scan     6      reusable-ferrflow-release  3
reusable-ci-go             5      reusable-ci-astro          3
reusable-docker-build      4      reusable-ci-node           2
reusable-ci-rust           3      reusable-release-rust      2
reusable-sbom-track        1      reusable-sonarqube-scan    1
reusable-renovate-dispatch 1 (valeur par défaut de l'input `runner`)
```

## Une seule exception, volontaire

Le job `integration` de `reusable-ci-rust` **reste ciblé par nom** :

```yaml
runs-on: ${{ ... 'ferrlabs-k8s' ... }}   # ligne 240, inchangée
```

Il parle à `postgres-ci.github-runner.svc.cluster.local`, interne au cluster de production. Routé par group, il échouerait sur une **résolution DNS** — sans rapport apparent avec la base, et seulement quand GitHub choisirait le Homelab, donc de façon intermittente. La garde ajoutée en #186 est juste au-dessus de cette ligne.

## Non touchés

`ferrlabs-k8s-large` et `ferrlabs-k8s-light` gardent leur ciblage par nom : ce sont des **tiers**, pas des sites. Les mettre dans un group laisserait un job lourd atterrir sur un runner `light` (0,5 CPU, 512 Mi, sans buildah), et un job trivial monopoliser le tier le plus rare.

## Vérifié avant bascule

Tous les services appelés par ces workflows sont publics, donc joignables depuis le Homelab :

```
crates.ferrlabs.com · dtrack.ferrlabs.com · sonar.ferrlabs.com
```

`postgres-ci` est la seule dépendance in-cluster du dépôt — d'où l'unique exception ci-dessus.

Les 14 workflows passent la validation YAML.

## Différences du site Homelab à surveiller

- **pas de miroir de registre** : le namespace `registry` n'existe que sur la production, les pulls partent vers l'amont (premier tirage plus lent, pas d'échec attendu) ;
- **connexion résidentielle** : débit et latence inférieurs ;
- **limites identiques** au tier medium de production (2 CPU, 6 Gi, 10 Gi éphémère) — c'est la condition de l'interchangeabilité.

## Propagation et retour arrière

⚠️ Les dépôts épinglent les réutilisables **par SHA**, et c'est Renovate qui les bump, toutes les 6 h. La bascule ne prend donc effet que progressivement, dépôt par dépôt — ce qui donne une fenêtre d'observation naturelle.

En cas de problème : revert de cette PR. Les jobs repartent sur la production, sans manipulation côté cluster.
