### PR TITLE
revert(ci): rétablit le ciblage des runners par nom

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -104,7 +104,7 @@ jobs:
     name: Build & Check
     # medium (was -large): astro/vite build fits on 1 CPU / 3Gi and this frees
     # the scarce 2-slot -large tier for the heavy Rust build/test/coverage jobs.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -144,7 +144,7 @@ jobs:
   i18n:
     name: i18n parity
     if: inputs.enable-i18n
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -172,7 +172,7 @@ jobs:
     name: Lighthouse CI
     needs: build
     if: inputs.enable-lighthouse && (github.event_name == 'pull_request' || !inputs.lighthouse-only-pr)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -92,7 +92,7 @@ permissions:
 jobs:
   detect:
     name: Detect Go module
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -117,7 +117,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -155,7 +155,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -208,7 +208,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -244,7 +244,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -136,7 +136,7 @@ jobs:
     name: Test & Build
     # medium (was -large): the node/vite build fits on 1 CPU / 3Gi and this
     # frees the scarce 2-slot -large tier for the heavy Rust jobs.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -217,7 +217,7 @@ jobs:
   quality:
     name: Quality (knip, madge, audit)
     if: inputs.enable-knip || inputs.enable-madge || inputs.enable-audit
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -230,13 +230,11 @@ jobs:
       PGHOST: ${{ inputs.integration-db-host }}
       PGPORT: ${{ inputs.integration-db-port }}
       PGUSER: ${{ inputs.integration-db-user }}
-    # NE JAMAIS basculer ce job sur `group=ferrlabs-k8s`. Il parle a
-    # postgres-ci.github-runner.svc.cluster.local, un service INTERNE au cluster
-    # de production. Le runner group contient aussi le site Homelab, d'ou ce
-    # service est injoignable : le job y echouerait sur une resolution DNS, sans
-    # rapport apparent avec la base. Cibler le scale set par son NOM reste
-    # possible meme s'il appartient a un group -- c'est exactement ce qu'on fait
-    # ici, et il faut le conserver.
+    # Ce job parle a postgres-ci.github-runner.svc.cluster.local, un service
+    # INTERNE au cluster de production : il doit rester sur `ferrlabs-k8s` et
+    # ne jamais etre route vers un autre site (le Homelab, par exemple), d'ou
+    # ce service est injoignable -- l'echec serait une resolution DNS, sans
+    # rapport apparent avec la base de donnees.
     runs-on: ${{ inputs.integration-runner != '' && inputs.integration-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
@@ -335,7 +333,7 @@ jobs:
         github.event_name != 'push' ||
         !startsWith(github.event.head_commit.message, 'chore(release):')
       )
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -396,7 +394,7 @@ jobs:
   typos:
     name: Typos
     if: inputs.enable-typos
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: crate-ci/typos@3bc303c295c081add5df4a4d52a1e117f2fb2dce # master

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -107,7 +107,7 @@ jobs:
     # hadolint via its static binary (not the hadolint-action Docker container)
     # so it runs on the self-hosted pool for private repos — the ARC runners
     # have buildah but no Docker daemon. Public repos fall back to ubuntu-latest.
-    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Lint Dockerfile (hadolint)
@@ -271,7 +271,7 @@ jobs:
     # medium, not inputs.runner (-large): Trivy just pulls the pushed image
     # from the registry and scans it — no buildah/compile, so it doesn't need
     # the scarce 2-slot large tier. Frees a large slot per docker-build run.
-    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       # Trivy reads ~/.docker/config.json to pull the image; without this a
       # private GHCR image fails with a 401/manifest-unknown.
@@ -324,7 +324,7 @@ jobs:
     # self-hosted pool for private repos. Public repos fall back to ubuntu-latest.
     # Keyless signing uses the Actions OIDC token, which is available on
     # self-hosted runners too (needs id-token: write, already granted).
-    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       - name: Install cosign
         run: |
@@ -363,7 +363,7 @@ jobs:
     if: inputs.push
     # medium, not inputs.runner (-large): Syft pulls the pushed image and
     # generates the SBOM — no buildah/compile, so no need for the large tier.
-    runs-on: ${{ github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       # Syft pulls the image via the Docker keychain (~/.docker/config.json);
       # a private GHCR image needs this login or the scan fails to fetch it.

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -59,7 +59,7 @@ jobs:
   release:
     name: Release with FerrFlow
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -89,7 +89,7 @@ jobs:
     # publish` is idempotent against the registry, so re-running publishes only
     # what's tagged-but-missing (recovers the index-lag / partial-publish case).
     if: ${{ inputs.deferred-publish && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -115,7 +115,7 @@ jobs:
     name: Trigger Renovate scan on consumers
     needs: release
     if: ${{ inputs.trigger-renovate && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - name: Dispatch Renovate workflow
         env:

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -109,7 +109,7 @@ jobs:
   upload:
     name: Attest + upload assets
     needs: build
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -133,7 +133,7 @@ jobs:
     name: Publish crates.io
     needs: upload
     if: inputs.crate-publish
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -24,7 +24,7 @@ on:
       runner:
         description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
         type: string
-        default: 'group=ferrlabs-k8s'
+        default: 'ferrlabs-k8s'
 
 permissions: {}
 

--- a/.github/workflows/reusable-sbom-track.yml
+++ b/.github/workflows/reusable-sbom-track.yml
@@ -54,7 +54,7 @@ permissions:
 jobs:
   sbom:
     name: SBOM → Dependency-Track
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -76,7 +76,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -118,7 +118,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -169,7 +169,7 @@ jobs:
 
   opengrep:
     name: opengrep (SAST)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -254,7 +254,7 @@ jobs:
 
   zizmor:
     name: zizmor (GitHub Actions security)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -295,7 +295,7 @@ jobs:
 
   trufflehog:
     name: trufflehog (secrets, deep history)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (!github.event.repository.private || inputs.run-on-private) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -333,7 +333,7 @@ jobs:
 
   snyk:
     name: snyk (deps)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -53,7 +53,7 @@ permissions:
 jobs:
   sonarqube:
     name: SonarQube analysis
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'group=ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
🚨 **Revert urgent de #187 et #191.** À fusionner sans attendre : tout dépôt qui monte son épingle vers ces SHA voit ses jobs bloqués indéfiniment.

## Ce qui se passe

`runs-on: group=ferrlabs-k8s` **ne fonctionne pas avec les runner scale sets ARC.** Preuve d'exécution, sur un job Astro de FerrLabs/Status :

```
Requested labels: group=ferrlabs-k8s
Waiting for a runner to pick up this job...
```

GitHub interprète `group=ferrlabs-k8s` comme un **label demandé**, et non comme un sélecteur de runner group. Or les runners ARC s'enregistrent **sans aucun label** :

```
$ gh api orgs/FerrLabs/actions/runners --jq '.runners[0] | {name, labels}'
{"labels": [], "name": "ferrlabs-k8s-large-sw8dg-runner-9hjn9"}
```

Aucun runner ne peut donc satisfaire la demande. Le job attend pour toujours — **sur les deux sites**, production comprise. Ce n'est pas un problème de répartition : c'est un `runs-on` qui ne matche rien.

La syntaxe `group=` appartient au modèle des runners auto-hébergés classiques, qui portent labels et groupe. Pour ARC, la [documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/using-actions-runner-controller-runners-in-a-workflow) est explicite : `runs-on` prend le **nom d'installation du scale set**, et ne mentionne aucune syntaxe `group=`.

## Contenu

Les 30 occurrences reviennent au ciblage par nom (`'ferrlabs-k8s'`). Le commentaire de garde du job `integration` est corrigé : il invoquait un mécanisme de group qui n'existe pas ; il énonce désormais la vraie contrainte — ce job dépend de `postgres-ci`, interne au cluster de production, et ne doit jamais être routé ailleurs.

## Impact constaté

Seul FerrLabs/Status avait monté son épingle (Status#138) et a des jobs bloqués. Les autres dépôts pointent encore l'ancien SHA et ne sont pas affectés — la lenteur de propagation par Renovate a limité la casse.

**Après fusion** : relancer les exécutions bloquées de Status, ou attendre que son épingle repointe un SHA sain.

## Le fond du problème reste entier

Le runner group `ferrlabs-k8s` (id 9) contient bien les deux scale sets — production (id 12) et Homelab (id 13), contrôleurs alignés en 0.10.1. Mais **un runner group ne distribue pas les jobs entre scale sets** : il sert au contrôle d'accès (quels dépôts peuvent utiliser ces runners), pas au routage.

La capacité d'appoint du Homelab demande donc un autre mécanisme. Piste à instruire, documentée par GitHub : *« runner scale set names are unique within the runner group they belong to. To deploy multiple scale sets sharing the same name, they must be in different runner groups. »* Deux scale sets portant le **même nom** dans des **groups différents** pourraient répondre au même `runs-on: ferrlabs-k8s` — reste à vérifier si GitHub répartit réellement dans ce cas, ce qui n'est documenté nulle part et devra être testé.
