### PR TITLE
fix(renovate): drop the inert confidence gate, raise npm quarantine to 3 days

### DIFF
--- a/default.json
+++ b/default.json
@@ -101,7 +101,7 @@
       "groupName": "FerrLabs Cargo crates"
     },
     {
-      "description": "Third-party npm — wait 1 day after release before opening PR (supply-chain quarantine), auto-merge only if mergeConfidence is high/very-high",
+      "description": "Third-party npm — quarantine for 3 days after release before opening PR, then auto-merge patch/minor. Release age is the only gate: this rule used to carry `matchMergeConfidence`, which is not a real Renovate option (the real one is `matchConfidence`) and therefore matched nothing, so the confidence gate never applied. Rather than adopt `matchConfidence` — which needs a Mend API key and reports `neutral` without one, silently disabling npm automerge everywhere — the quarantine is raised from 1 to 3 days, which is where most malicious publishes are detected and yanked. npm is deliberately stricter than the Cargo rule below: it is the ecosystem where these attacks actually land.",
       "matchManagers": [
         "npm"
       ],
@@ -112,11 +112,7 @@
         "patch",
         "minor"
       ],
-      "matchMergeConfidence": [
-        "high",
-        "very high"
-      ],
-      "minimumReleaseAge": "1 day",
+      "minimumReleaseAge": "3 days",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"


### PR DESCRIPTION
Closes #193

The third-party npm rule advertised two gates — a release-age quarantine and a merge-confidence check — but only one of them existed. `matchMergeConfidence` is not a Renovate option (the real one is `matchConfidence`), so it matched nothing and constrained nothing. Every third-party npm patch and minor has been auto-merging on release age alone, across every repo consuming this preset.

`renovate-config-validator` on `main` before this change:

```
"topic": "Configuration Error",
"message": "Invalid configuration option: packageRules[3].matchMergeConfidence"
```

## Approach

Option 2 from the issue — remove the dead option and strengthen the gate that actually works.

The alternative was renaming to `matchConfidence`, which sounds like the obvious fix but is not: it needs a Mend merge-confidence API key, and **without one every package reports `neutral`**, which would not match `["high", "very high"]`. The rule would stop matching entirely and npm auto-merge would silently switch off org-wide — a large behavioural change arriving as a side effect of a typo fix. That is a decision worth making deliberately, not by accident, so it stays available as a follow-up rather than being smuggled in here.

## Change

- `matchMergeConfidence` removed
- `minimumReleaseAge`: `1 day` → **`3 days`**

Three days is where most malicious publishes are detected and yanked; one day catches only the fastest cases. This deliberately makes npm stricter than the sibling Cargo rule (still 1 day) — npm is where these attacks actually land, and that rule's own comment already acknowledges release age is its only gate.

The description now states what the rule does rather than what it was believed to do, and records why `matchConfidence` was not adopted, so the next reader does not re-litigate it.

## Verification

```
npx --package renovate renovate-config-validator default.json
INFO: Config validated successfully against 1 file(s)
```

The file is now clean end to end — this and the `vulnerabilityAlerts.prPriority` removal in #192 were the only two findings the validator had.

## Trade-off worth naming

Routine patches now wait three days instead of one. For a security-relevant bump that is too slow — but those come through `vulnerabilityAlerts`, which has its own `minimumReleaseAge: 0` and is unaffected by this rule.
