### PR TITLE
perf(ci-rust): n'interroge apt que si un paquet manque vraiment

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -179,10 +179,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -245,10 +264,20 @@ jobs:
         name: Install apt packages
         env:
           APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Same guard as the other jobs: see the comment on the first one.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends $APT_PACKAGES
+          $SUDO apt-get install -y --no-install-recommends $missing
       - name: Install postgresql-client
         run: |
           if command -v createdb >/dev/null 2>&1; then exit 0; fi
@@ -341,10 +370,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -419,10 +467,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}


### PR DESCRIPTION
Observé sur FerrFleet-Cloud aujourd'hui, mais le défaut est ici et concerne **tout dépôt Rust qui passe `apt-packages`** — FerrVault et consorts envoient les trois mêmes.

```
Fetched 32.0 MB in 28min 58s (18.4 kB/s)
build-essential is already the newest version (12.10ubuntu1).
pkg-config is already the newest version (1.8.1-2build1).
libssl-dev is already the newest version (3.0.13-0ubuntu3.12).
0 upgraded, 0 newly installed, 0 to remove
```

**29 minutes pour installer zéro paquet.** L'image des runners self-hosted porte ces paquets ; l'étape ne faisait que télécharger des listes pour conclure qu'elle n'avait rien à faire.

## Le correctif

`dpkg -s` d'abord, sortie immédiate si tout est présent, et sinon on n'installe que ce qui manque réellement. Appliqué aux **quatre** occurrences de l'étape.

C'est exactement le motif que suit déjà l'étape `Install postgresql-client` juste à côté (`command -v createdb` puis sortie) — donc l'intention existait, elle n'avait simplement pas été portée ici.

Au passage, les trois occurrences qui interpolaient `${{ inputs.apt-packages }}` directement dans le `run` passent par `env:`, comme le faisait déjà la quatrième.

## Le débit, séparément

18,4 ko/s reste anormal. Mesuré depuis le nœud : 53 Mo/s vers github.com, 637 ko/s vers archive.ubuntu.com. Le pod a donc obtenu **35× moins que son hôte** sur la même destination — un problème d'egress des pods que cette PR ne résout pas, mais dont elle supprime l'exposition sur ce chemin.

## Portée

Les dépôts épinglent ce workflow par SHA ; le changement ne se propagera qu'au rythme de Renovate, dépôt par dépôt.