### PR TITLE
feat(sonarqube): analyse les PR dans un projet dédié et commente le delta

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -179,10 +179,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -245,10 +264,20 @@ jobs:
         name: Install apt packages
         env:
           APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Same guard as the other jobs: see the comment on the first one.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends $APT_PACKAGES
+          $SUDO apt-get install -y --no-install-recommends $missing
       - name: Install postgresql-client
         run: |
           if command -v createdb >/dev/null 2>&1; then exit 0; fi
@@ -341,10 +370,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -419,10 +467,29 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - if: inputs.apt-packages != '' && runner.os == 'Linux'
         name: Install apt packages
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        # Ask dpkg before asking the network. Callers pass build deps that the
+        # self-hosted runner image already ships, so this step used to spend its
+        # whole time in `apt-get update` and install nothing: one run fetched
+        # 32 MB of package lists at 18 kB/s — 29 minutes — to report "0
+        # upgraded, 0 newly installed".
+        #
+        # Kept rather than dropped: a runner whose image lacks a package must
+        # still get it, and only what is genuinely missing is then fetched.
         run: |
+          missing=""
+          for pkg in $APT_PACKAGES; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+          done
+          if [ -z "$missing" ]; then
+            echo "already present, skipping apt: $APT_PACKAGES"
+            exit 0
+          fi
+          echo "missing:$missing"
           if command -v sudo >/dev/null 2>&1; then SUDO=sudo; else SUDO=; fi
           $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends ${{ inputs.apt-packages }}
+          $SUDO apt-get install -y --no-install-recommends $missing
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ inputs.rust-toolchain }}

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -49,11 +49,33 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   sonarqube:
     name: SonarQube analysis
     runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    # Pull requests all analyse into the same `<key>-pr` sandbox project, so two
+    # concurrent PRs on one repo would overwrite each other's analysis. Serialise
+    # them per repo. Pushes to the default branch are unaffected (own group).
+    concurrency:
+      group: sonar-${{ inputs.project-key || github.event.repository.name }}-${{ github.event_name == 'pull_request' && 'pr' || github.ref }}
+      cancel-in-progress: false
+    env:
+      SONAR_HOST: ${{ vars.SONAR_HOST_URL || 'https://sonar.ferrlabs.com' }}
+      # SonarQube Community has no branch or pull-request analysis — the
+      # `api/project_pull_requests/*` endpoints return 404, and a scan carries no
+      # branch identity. So a scan launched from a PR used to land on the
+      # project's ONLY analysis and overwrite the default branch's picture with
+      # the PR's code: the dashboard showed whichever run finished last, and
+      # every "new code" figure was meaningless.
+      #
+      # A pull request therefore analyses into its own sandbox project. The
+      # default branch keeps a clean, stable analysis, and the two projects are
+      # comparable, which is what lets the diff step below report what this pull
+      # request actually introduces.
+      BASE_PROJECT: ${{ inputs.project-key || github.event.repository.name }}
+      SONAR_PROJECT: ${{ github.event_name == 'pull_request' && format('{0}-pr', inputs.project-key || github.event.repository.name) || (inputs.project-key || github.event.repository.name) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -96,11 +118,176 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonar.ferrlabs.com' }}
+          SONAR_HOST_URL: ${{ env.SONAR_HOST }}
         with:
           projectBaseDir: ${{ inputs.working-directory }}
           args: >
-            -Dsonar.projectKey=${{ inputs.project-key || github.event.repository.name }}
+            -Dsonar.projectKey=${{ env.SONAR_PROJECT }}
             -Dsonar.exclusions=${{ inputs.exclusions }}
             ${{ steps.sast.outputs.scanner-args }}
             ${{ inputs.args }}
+
+      # Everything below only runs on a pull request. It turns the two analyses
+      # (this PR's sandbox, and the default branch) into the one thing a reviewer
+      # wants: what did THIS change introduce.
+
+      - name: Wait for SonarQube to finish processing
+        if: github.event_name == 'pull_request'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        working-directory: ${{ inputs.working-directory }}
+        # The scanner returns as soon as the report is uploaded; SonarQube
+        # ingests it asynchronously. Querying the API before the compute-engine
+        # task finishes returns the PREVIOUS analysis, so the diff would silently
+        # describe the wrong commit. report-task.txt carries the task id.
+        run: |
+          set -euo pipefail
+          task=$(grep '^ceTaskId=' .scannerwork/report-task.txt | cut -d= -f2)
+          for _ in $(seq 1 60); do
+            status=$(curl -sS -u "${SONAR_TOKEN}:" "${SONAR_HOST}/api/ce/task?id=${task}" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["task"]["status"])')
+            case "$status" in
+              SUCCESS) echo "analyse ingérée"; exit 0 ;;
+              FAILED|CANCELED) echo "::error::SonarQube task $status"; exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo "::error::SonarQube n'a pas fini d'ingérer l'analyse en 5 minutes"
+          exit 1
+
+      - name: Diff against the default branch
+        id: diff
+        if: github.event_name == 'pull_request'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, urllib.request, urllib.parse, base64, pathlib
+
+          host   = os.environ["SONAR_HOST"].rstrip("/")
+          token  = os.environ["SONAR_TOKEN"]
+          gh     = os.environ["GH_TOKEN"]
+          repo   = os.environ["REPO"]
+          pr     = os.environ["PR_NUMBER"]
+
+          def get(url, headers):
+              req = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(req, timeout=60) as r:
+                  return json.load(r)
+
+          sonar_auth = {"Authorization": "Basic " + base64.b64encode(f"{token}:".encode()).decode()}
+          gh_auth = {"Authorization": f"Bearer {gh}", "Accept": "application/vnd.github+json"}
+
+          def issues(project):
+              """Every open issue of a project, keyed by what survives a rebase."""
+              out, page = {}, 1
+              while True:
+                  q = urllib.parse.urlencode({
+                      "componentKeys": project, "resolved": "false",
+                      "ps": 500, "p": page,
+                  })
+                  d = get(f"{host}/api/issues/search?{q}", sonar_auth)
+                  for i in d.get("issues", []):
+                      # Deliberately NOT keyed on line number: a pull request that
+                      # only shifts lines would otherwise report every pre-existing
+                      # issue in the file as newly introduced.
+                      path = i.get("component", "").split(":", 1)[-1]
+                      out[(i.get("rule"), path, i.get("message"))] = i
+                  if page * 500 >= d.get("paging", {}).get("total", 0):
+                      return out
+                  page += 1
+
+          changed = set()
+          page = 1
+          while True:
+              d = get(f"https://api.github.com/repos/{repo}/pulls/{pr}/files?per_page=100&page={page}", gh_auth)
+              if not d:
+                  break
+              changed.update(f["filename"] for f in d)
+              if len(d) < 100:
+                  break
+              page += 1
+
+          pr_issues   = issues(os.environ["SONAR_PROJECT"])
+          base_issues = issues(os.environ["BASE_PROJECT"])
+
+          introduced = [
+              v for k, v in pr_issues.items()
+              if k not in base_issues and k[1] in changed
+          ]
+          fixed = [
+              v for k, v in base_issues.items()
+              if k not in pr_issues and k[1] in changed
+          ]
+
+          rank = {"BLOCKER": 0, "HIGH": 1, "CRITICAL": 1, "MEDIUM": 2, "MAJOR": 2, "LOW": 3, "MINOR": 3, "INFO": 4}
+          introduced.sort(key=lambda i: rank.get(i.get("severity", "INFO"), 9))
+
+          pathlib.Path("sonar-delta.json").write_text(json.dumps({
+              "introduced": introduced, "fixed": len(fixed),
+              "host": host, "project": os.environ["SONAR_PROJECT"],
+          }))
+          print(f"{len(introduced)} introduite(s), {len(fixed)} corrigée(s)")
+          PY
+
+      - name: Comment on the pull request
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, urllib.request
+
+          d = json.load(open("sonar-delta.json"))
+          gh, repo, pr = os.environ["GH_TOKEN"], os.environ["REPO"], os.environ["PR_NUMBER"]
+          # One comment per pull request, found by this marker and edited in
+          # place. A scan runs on every push; without this the thread fills with
+          # near-identical comments and nobody reads any of them.
+          MARKER = "<!-- ferrlabs-sonar-delta -->"
+
+          intro = d["introduced"]
+          if intro:
+              lines = [f"### SonarQube — {len(intro)} issue(s) introduite(s) par cette PR", ""]
+              for i in intro[:25]:
+                  path = i.get("component", "").split(":", 1)[-1]
+                  line = i.get("line") or (i.get("textRange") or {}).get("startLine")
+                  where = f"`{path}`" + (f" L{line}" if line else "")
+                  lines.append(f"- **{i.get('severity','?')}** {where} — {i.get('message')}  <sub>`{i.get('rule')}`</sub>")
+              if len(intro) > 25:
+                  lines.append(f"\n_… et {len(intro) - 25} autres._")
+          else:
+              lines = ["### SonarQube — aucune nouvelle issue", ""]
+          if d["fixed"]:
+              lines.append(f"\n{d['fixed']} issue(s) corrigée(s) sur les fichiers touchés.")
+          lines.append(
+              "\n<sub>Comparaison entre le projet bac à sable de cette PR et la branche par défaut : "
+              "SonarQube Community n'analyse pas les PR, ce delta est calculé côté CI. "
+              f"[Détail]({d['host']}/dashboard?id={d['project']})</sub>"
+          )
+          body = MARKER + "\n" + "\n".join(lines)
+
+          def api(method, url, payload=None):
+              req = urllib.request.Request(
+                  url, method=method,
+                  data=json.dumps(payload).encode() if payload else None,
+                  headers={"Authorization": f"Bearer {gh}",
+                           "Accept": "application/vnd.github+json",
+                           "Content-Type": "application/json"})
+              with urllib.request.urlopen(req, timeout=30) as r:
+                  return json.load(r)
+
+          existing = next(
+              (c for c in api("GET", f"https://api.github.com/repos/{repo}/issues/{pr}/comments?per_page=100")
+               if MARKER in c.get("body", "")), None)
+          if existing:
+              api("PATCH", f"https://api.github.com/repos/{repo}/issues/comments/{existing['id']}", {"body": body})
+          else:
+              api("POST", f"https://api.github.com/repos/{repo}/issues/{pr}/comments", {"body": body})
+          PY


### PR DESCRIPTION
## Le bug que ça corrige d'abord

SonarQube Community n'a **ni analyse de branche ni analyse de PR** — `api/project_pull_requests/list` répond 404, et un scan ne porte aucune identité de branche.

Or ce workflow tournait aussi sur les `pull_request`. Chaque scan de PR atterrissait donc sur **l'unique analyse du projet** et écrasait l'image de la branche par défaut avec le code de la PR. Le tableau de bord montrait le dernier run arrivé, quel qu'il soit, et toutes les métriques « new code » étaient du bruit.

Constaté sur `FerrFleet-Cloud` : quality gate en ERROR avec `new_violations: 60` et `new_coverage: 0.0`, sur une analyse dont on ne savait pas quel commit elle décrivait.

## Ce que fait cette PR

Une PR s'analyse désormais dans **son propre projet bac à sable** `<clé>-pr`. La branche par défaut garde une analyse propre et stable, et les deux projets deviennent comparables — ce qui permet la suite.

Trois étapes ajoutées, toutes conditionnées à `github.event_name == 'pull_request'` :

1. **Attendre l'ingestion.** Le scanner rend la main dès l'upload ; SonarQube ingère de façon asynchrone. Interroger l'API trop tôt renvoie l'analyse *précédente*, et le delta décrirait silencieusement le mauvais commit. On lit le `ceTaskId` de `report-task.txt` et on attend `SUCCESS`.
2. **Calculer le delta.** Issues du bac à sable moins issues de la branche par défaut, restreint aux fichiers que la PR touche. La clé de comparaison est `(règle, fichier, message)` — **volontairement sans le numéro de ligne** : sinon une PR qui décale des lignes rapporterait toute la dette existante du fichier comme nouvellement introduite.
3. **Commenter.** Un seul commentaire par PR, retrouvé par un marqueur `<!-- ferrlabs-sonar-delta -->` et **édité sur place**. Un scan tourne à chaque push ; sans ça le fil se remplit de commentaires quasi identiques et plus personne ne les lit.

## Détails

`concurrency` sérialise les PR d'un même repo : elles partagent le projet `-pr`, deux analyses simultanées s'écraseraient. Les push sur la branche par défaut ont leur propre groupe et ne sont pas ralentis.

`permissions` déclare `pull-requests: write`. Un workflow appelé ne peut pas recevoir moins qu'il ne déclare : **les appelants doivent accorder cette permission au job**, sinon l'appel échoue au démarrage.

## Ce que ça ne donne pas

Pas les métriques `new_*` de SonarQube — elles exigent une vraie analyse de branche, donc une édition payante. Le delta est calculé côté CI. Le commentaire le dit explicitement pour que personne ne s'y trompe.
