### PR TITLE
chore(deps): bump FerrFlow to v5.52.0 in the reusable release workflow

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -71,7 +71,7 @@ jobs:
       # repo has a Cargo.toml.
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: FerrLabs/FerrFlow@b1b4e96d8baf53b7ef5f0e0273e1a06761ef9571 # v5.49.0
+      - uses: FerrLabs/FerrFlow@de4e8cf69468b3df3e65d4d79a05b60973d051d7 # v5.52.0
         env:
           # Lets cargo-based postBump hooks read the private Kellnr index.
           # Empty (and unused) for repos that don't consume Kellnr.
@@ -103,7 +103,7 @@ jobs:
       # private Kellnr index for dependency metadata).
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: FerrLabs/FerrFlow@b1b4e96d8baf53b7ef5f0e0273e1a06761ef9571 # v5.49.0
+      - uses: FerrLabs/FerrFlow@de4e8cf69468b3df3e65d4d79a05b60973d051d7 # v5.52.0
         env:
           CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
         with:


### PR DESCRIPTION
Bumps both `FerrLabs/FerrFlow` pins in `reusable-ferrflow-release.yml` from v5.49.0 to v5.52.0 (`de4e8cf`) — the `release` job and the `publish` job.

What lands with it:

| PR | Change |
| --- | --- |
| FerrLabs/FerrFlow#781 | `ferrflow diff` scopes the range to the named package in a monorepo |
| FerrLabs/FerrFlow#782 | the dependency cascade propagates the upstream bump type instead of always patching |
| FerrLabs/FerrFlow#783 | `updateDependents` rewrites dependents' version constraints (opt-in, off by default) |
| FerrLabs/FerrFlow#784 | new `ferrflow why` command |
| FerrLabs/FerrFlow#785 | the hosted bot exchanges its token on `api.ferrflow.com` |

### One behaviour change that actually reaches a repo: #782

**`Kit` is affected, and it picks this up on its very next release** — its `release.yml` calls this workflow at `@main`, not at a pinned SHA.

Kit declares a real `dependsOn` graph:

```
ferrlabs-errors ← types, crypto, db, auth, billing, middleware
ferrlabs-types  ← db, auth, billing, middleware
```

Before this bump, a `feat!` in `ferrlabs-errors` gave every one of those dependents a **patch**. After it, they take a **major**. For crates published to Kellnr and consumed by every product API that is arguably the correct reading — a breaking change in the error type genuinely is breaking for anything re-exporting it — but it is a much larger version jump than Kit has been getting, and it is not what anyone will expect unless they read this.

If Kit should keep the old behaviour, the per-dependency opt-out shipped in the same release:

```json
"dependsOn": [{ "name": "ferrlabs-errors", "propagate": "patch" }]
```

I have deliberately not made that change — it is Kit's call, not a side effect of a pin bump. Say the word and I will.

Also at `@main` and therefore immediate: `MCP`, `Status`, `Finance`. None of them declare `dependsOn`, so #782 is a no-op for them.

Every other repo pins this workflow by SHA (`d3ce80b`, `2a5ffda`, `5d33e5b`, `e4fa4cc` — several still carrying v5.47.1), so they pick the new CLI up only when Renovate rolls their `.github` pin. Nothing changes for them today.

### The bot endpoint

#785 moves the default token exchange to `https://api.ferrflow.com/v1/ferrflow/token`, now served by the dedicated `ferrflow-api` service (FerrLabs/Infra#250). `api.ferrlabs.com/api/v1/ferrflow/token` stays live permanently for already-released binaries, and `bot_endpoint:` still overrides both.

This bump is what first sends real OIDC traffic to that new service — the pod is deployed and its GitHub App key is loaded (it answers `401 OIDC_INVALID`, not `503 NOT_CONFIGURED`), but the App-JWT-signing and installation-lookup legs have not been exercised by a real runner yet. Kit's next release is the first live test. If it fails, the fix is one line: set `bot_endpoint: https://api.ferrlabs.com/api/v1/ferrflow/token` on the affected job.
