### PR TITLE
fix(ci): ajoute la permission packages: read

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -98,6 +98,19 @@ on:
 
 permissions:
   contents: read
+  # Lecture du registre npm de GitHub (`npm.pkg.github.com`), où vivent les
+  # paquets `@ferrlabs/*`.
+  #
+  # Sans cette permission, le repli sur `GITHUB_TOKEN` ne peut pas fonctionner :
+  # il est émis sans droit sur les paquets, et l'installation échoue en 401. Le
+  # CI ne tenait donc que par le PAT `FERRFLOW_PACKAGES_READ`, sans que la
+  # dépendance soit visible — un secret d'organisation absent aurait produit une
+  # erreur d'authentification incompréhensible plutôt qu'un repli.
+  #
+  # C'est aussi le préalable pour se passer de ce PAT classique (Infra#264) :
+  # une fois l'accès Actions du paquet accordé aux dépôts consommateurs,
+  # `GITHUB_TOKEN` suffit.
+  packages: read
 
 jobs:
   build:

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -130,6 +130,19 @@ on:
 
 permissions:
   contents: read
+  # Lecture du registre npm de GitHub (`npm.pkg.github.com`), où vivent les
+  # paquets `@ferrlabs/*`.
+  #
+  # Sans cette permission, le repli sur `GITHUB_TOKEN` ne peut pas fonctionner :
+  # il est émis sans droit sur les paquets, et l'installation échoue en 401. Le
+  # CI ne tenait donc que par le PAT `FERRFLOW_PACKAGES_READ`, sans que la
+  # dépendance soit visible — un secret d'organisation absent aurait produit une
+  # erreur d'authentification incompréhensible plutôt qu'un repli.
+  #
+  # C'est aussi le préalable pour se passer de ce PAT classique (Infra#264) :
+  # une fois l'accès Actions du paquet accordé aux dépôts consommateurs,
+  # `GITHUB_TOKEN` suffit.
+  packages: read
 
 jobs:
   test:


### PR DESCRIPTION
Les workflows réutilisables Node et Astro installent des paquets `@ferrlabs/*` depuis `npm.pkg.github.com`, mais déclarent seulement `contents: read`.

Conséquence : le repli `secrets.GITHUB_TOKEN` de la chaîne

```
FERRLABS_PACKAGES_READ || FERRFLOW_PACKAGES_READ || GITHUB_TOKEN
```

ne peut pas fonctionner — un `GITHUB_TOKEN` émis sans droit sur les paquets prend un 401. Le CI ne tenait donc que par le PAT, sans que cette dépendance soit visible : un secret d'organisation absent aurait produit une erreur d'authentification incompréhensible plutôt qu'un repli.

C'est aussi le préalable pour se passer du PAT classique (FerrLabs/Infra#264).

## Ce que ça ne corrige pas

L'échec en cours sur `@ferrlabs/ui-foundation` :

```
[ERR_PNPM_FETCH_401] GET https://npm.pkg.github.com/@ferrlabs%2Fui-foundation: Unauthorized - 401
```

Il touche **tous** les consommateurs — FerrVault-Cloud, FerrTrack-Cloud, FerrLabs-Cloud, FerrGrowth-Cloud, FerrLens-Cloud — depuis le 2026-08-05 à 16h48.

Ce que la mesure établit :

| | |
|---|---|
| `FERRFLOW_PACKAGES_READ` | inchangé depuis le 2026-05-05 |
| `@ferrlabs/ui-ng`, même dépôt source | se résout normalement (CI FerrGames vert) |
| `foundation@v5.2.0` | publié le 2026-07-16 |
| dernier CI vert sur FerrVault-Cloud | 2026-08-04 |

Le jeton est donc valide et n'a pas bougé : c'est l'accès **à ce paquet précis** qui manque. Il faut regarder les réglages du paquet `ui-foundation` — « Manage Actions access » — et y autoriser les dépôts consommateurs, ou aligner sa visibilité sur celle de `ui-ng`.

Une fois cet accès accordé, cette PR permet à `GITHUB_TOKEN` de prendre le relais et le PAT devient superflu.