### PR TITLE
feat(ci): route les scans légers vers le palier light

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -63,6 +63,23 @@ on:
         type: string
         required: false
         default: ''
+      light-runner:
+        description: >-
+          Runner pour les scans LÉGERS (gitleaks, zizmor, osv-scanner) : des
+          binaires qui lisent des fichiers et un lockfile. Vide (défaut) =
+          `ferrlabs-k8s-light` sur les dépôts privés.
+
+          Les trois autres jobs restent sur `runner` : `opengrep` est un moteur
+          SAST qui charge l'arbre syntaxique du dépôt et dépasse couramment le
+          gigaoctet, `trufflehog` clone l'historique complet, et `snyk` résout
+          l'arbre de dépendances. Les envoyer sur `light` produirait des OOM,
+          pas un ralentissement.
+
+          Ignoré si `runner` est fourni : un appelant qui impose un runner
+          l'impose partout.
+        type: string
+        required: false
+        default: ''
       run-on-private:
         description: 'Set to `true` to run the scans on private repos too. Defaults to `false` because GitHub-hosted runners consume billed minutes on private repos and our security scans are best-effort hygiene, not blocking gates. Public repos always run (Actions are free for them).'
         type: boolean
@@ -76,7 +93,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || inputs.light-runner != '' && inputs.light-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -118,7 +135,7 @@ jobs:
 
   osv-scanner:
     name: osv-scanner (CVE)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || inputs.light-runner != '' && inputs.light-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -254,7 +271,7 @@ jobs:
 
   zizmor:
     name: zizmor (GitHub Actions security)
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || inputs.light-runner != '' && inputs.light-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     if: ${{ !github.event.repository.private || inputs.run-on-private }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Route les scans de sécurité légers vers le palier `ferrlabs-k8s-light`, qui existe pour ça et reste largement sous-utilisé.

## Répartition

| job | palier | pourquoi |
|---|---|---|
| `gitleaks` | **light** | lit des fichiers, binaire unique |
| `zizmor` | **light** | analyse statique de YAML |
| `osv-scanner` | **light** | lit un lockfile |
| `opengrep` | normal | moteur SAST : charge l'arbre syntaxique du dépôt, dépasse couramment le gigaoctet |
| `trufflehog` | normal | clone l'historique complet (`fetch-depth: 0`) |
| `snyk` | normal | résout l'arbre de dépendances |

Envoyer les trois derniers sur `light` ne produirait pas un ralentissement mais des OOM et des `No space left on device`.

## Nouvelle entrée `light-runner`

Le workflow n'avait qu'une seule entrée `runner` appliquée aux six jobs, ce qui interdisait toute répartition. `light-runner` la complète, avec cette précédence :

1. `runner` s'il est fourni — un appelant qui impose un runner l'impose partout ;
2. sinon `light-runner` pour les trois jobs légers ;
3. sinon `ferrlabs-k8s-light` sur les dépôts privés, `ubuntu-latest` sur les publics.

Aucun appelant n'a besoin de changer : le comportement par défaut fait le bon choix.

## Dépendance

Nécessite FerrLabs/Kubernetes#140, qui relève le palier `light` de 512Mi à 1Gi de mémoire et de 2Gi à 5Gi de disque. `gitleaks` clone l'historique complet, ce qui ne tient pas dans les 2Gi actuels sur les gros dépôts.

À merger **après** #140, sans quoi les trois jobs déplacés échoueront sur des limites trop basses.

## Ce qui reste à vérifier

Les seuils de `opengrep` et `snyk` sont des estimations, pas des mesures. Si l'un des deux s'avère plus léger que supposé, il pourra rejoindre le palier `light` — mais ça se constate sur un scan réel, pas sur une intuition.
