### PR TITLE
chore(ci): épingle FerrFlow v6.1.0 dans le reusable de release

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -71,7 +71,7 @@ jobs:
       # repo has a Cargo.toml.
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: FerrLabs/FerrFlow@de4e8cf69468b3df3e65d4d79a05b60973d051d7 # v5.52.0
+      - uses: FerrLabs/FerrFlow@fe0920351dfe89a30c81a0487181ec38c2209e88 # v6.1.0
         env:
           # Lets cargo-based postBump hooks read the private Kellnr index.
           # Empty (and unused) for repos that don't consume Kellnr.
@@ -103,7 +103,7 @@ jobs:
       # private Kellnr index for dependency metadata).
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: FerrLabs/FerrFlow@de4e8cf69468b3df3e65d4d79a05b60973d051d7 # v5.52.0
+      - uses: FerrLabs/FerrFlow@fe0920351dfe89a30c81a0487181ec38c2209e88 # v6.1.0
         env:
           CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
         with:


### PR DESCRIPTION
Monte l'épinglage de l'action `FerrLabs/FerrFlow` de **v5.52.0** à **v6.1.0** dans `reusable-ferrflow-release.yml`.

C'est l'étape qui débloque le retrait des montages `/v1` côté FerrLabs/FerrFlow-Cloud#788.

## Ce que ça change concrètement

| | v5.52.0 (actuel) | v6.1.0 |
|---|---|---|
| endpoint du jeton bot | `api.ferrflow.com/v1/ferrflow/token` | `api.ferrflow.com/ferrflow/token` |

Tant que cet épinglage vise `/v1`, **tous les dépôts de l'organisation** passent par ce chemin pour leur release — d'où l'impossibilité de retirer le montage.

## Pourquoi c'est sûr maintenant

`api:6.0.1` est déployée et sert **les deux** formes. Ce n'est pas une déduction : la release **v6.1.0 de FerrFlow s'est elle-même faite avec l'endpoint racine**, et son échange de jeton bot a réussi en production. Le job n'a rougi que sur une étape de notification postérieure, sans rapport (FerrLabs/FerrFlow#819).

## Ordre

1. Cette PR
2. Renovate propage le SHA aux dépôts (~6 h)
3. **Alors seulement** FerrLabs/FerrFlow-Cloud#788 — le retrait de `/v1`

Sauter l'étape 2 casserait la release de tout dépôt encore épinglé sur v5.52.0.

## Vérifié

Le SHA `fe09203` est bien le commit du tag `v6.1.0` (tag annoté déréférencé), et son `action.yml` porte `default: 'https://api.ferrflow.com/ferrflow/token'`. Le YAML parse.