### PR TITLE
fix(renovate): ajoute le shard games et répare le filet `rest`

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -76,11 +76,21 @@ jobs:
       #   - one shard per non-archived *-Cloud repo (each is a heavy
       #     api+web+docker monorepo, worth isolating so one slow/failing repo
       #     doesn't hold up the rest),
-      #   - grouped shards for tools / libs / infra,
+      #   - grouped shards for tools / libs / infra / games,
       #   - a `rest` catch-all owning every other non-archived repo.
-      # Shards are mutually exclusive and jointly exhaustive: a repo lands in
-      # exactly one, and any new repo not matching a named group falls into
-      # `rest`, so nothing is processed twice and nothing is silently dropped.
+      # Shards are mutually exclusive: un dépôt tombe dans exactement un.
+      #
+      # ⚠️ `rest` n'a jamais rien attrapé jusqu'au 2026-08-09 : le filtre
+      # s'écrivait `$named | index(.)`, où le `.` dans `index()` désigne
+      # l'entrée du pipe — c'est-à-dire `$named` lui-même, pas le dépôt
+      # courant. `$named | index($named)` vaut 0, donc `| not` valait false
+      # pour TOUT dépôt et `$rest` sortait toujours vide, sans erreur ni
+      # shard visible. Six dépôts n'ont donc jamais été scannés, dont
+      # FerrGames-Discord — qui consomme ce reusable de release.
+      #
+      # La forme `. as $n | $named | index($n)` capture la valeur courante
+      # avant le pipe. Si un shard `rest` apparaît dans un run, c'est normal :
+      # c'est ce qui manquait.
       - name: Compute shard matrix
         id: plan
         env:
@@ -101,15 +111,18 @@ jobs:
             --argjson repos "${repos}" \
             --argjson tools '["FerrFlow","FerrVault","Benchmarks","Fixtures",".github","MCP","Changelog","Status"]' \
             --argjson libs  '["Claude-Agents","actions-runner-image","UI","Kit"]' \
-            --argjson infra '["Infra","Kubernetes"]' '
+            --argjson infra '["Infra","Kubernetes"]' \
+            --argjson games '["FerrGames-Discord","ArchVeil","RogueLite","Idler-Survivor"]' '
             def flt($xs): [$xs[] | "FerrLabs/" + .] | join(",");
-            ($tools + $libs + $infra) as $named
+            ($tools + $libs + $infra + $games) as $named
             | ($repos | map(select(endswith("-Cloud")))) as $cloud
-            | ($repos | map(select((endswith("-Cloud") | not) and (($named | index(.)) | not)))) as $rest
+            | ($repos | map(select((endswith("-Cloud") | not)
+                                   and (. as $n | $named | index($n) | not)))) as $rest
             | ( ($cloud | map({shard: ., filter: ("FerrLabs/" + .)}))
                 + [ {shard: "tools", filter: (flt($tools))},
                     {shard: "libs",  filter: (flt($libs))},
-                    {shard: "infra", filter: (flt($infra))} ]
+                    {shard: "infra", filter: (flt($infra))},
+                    {shard: "games", filter: (flt($games))} ]
                 + (if ($rest | length) > 0 then [{shard: "rest", filter: (flt($rest))}] else [] end)
               ) as $inc
             | {include: $inc}')


### PR DESCRIPTION
Six dépôts n'étaient scannés par Renovate **depuis toujours**. Découvert en cherchant pourquoi FerrGames-Discord n'apparaissait dans aucun shard.

## Le bug : `rest` n'a jamais rien attrapé

```jq
map(select((endswith("-Cloud") | not) and (($named | index(.)) | not)))
```

Dans `$named | index(.)`, le `.` désigne **l'entrée du pipe** — c'est-à-dire `$named` lui-même, pas le dépôt courant. Donc :

```
$named | index($named)  →  0
0 | not                 →  false
```

Le prédicat valait `false` pour **tous** les dépôts. `$rest` sortait systématiquement vide, et comme le shard n'est ajouté que `if ($rest | length) > 0`, il ne s'affichait jamais dans la matrice. Aucune erreur, aucun avertissement : juste des dépôts absents.

Vérifiable en une ligne :

```console
$ jq -n '["a","b"] as $n | ("zzz" | ($n | index(.)))'
0
$ jq -n '["a","b"] as $n | ("zzz" | (. as $x | $n | index($x)))'
null
```

Le commentaire du workflow affirmait « nothing is silently dropped ». C'était exactement l'inverse.

## Conséquence

Jamais scannés : `NEURON.click`, `ArchVeil`, `RogueLite`, `Idler-Survivor`, `Homelab`, `FerrGames-Discord`.

Le dernier est le plus coûteux : il consomme `reusable-ferrflow-release.yml`, épinglé sur un SHA que Renovate n'a jamais monté. Il serait donc resté sur l'action v5.52.0 (endpoint `/v1`) pendant que tout le reste bascule — et sa release aurait cassé au retrait du montage `/v1` (FerrLabs/FerrFlow-Cloud#788), sans que rien ne l'ait signalé.

## Correctif

**Shard `games` nommé** — `FerrGames-Discord`, `ArchVeil`, `RogueLite`, `Idler-Survivor`. Un shard nommé construit son filtre à partir d'une liste statique : il ne dépend pas de l'énumération.

**`rest` réparé** — `. as $n | $named | index($n)` capture la valeur courante avant le pipe.

## Vérifié

Le `jq` corrigé, rejoué sur la liste réelle des 28 dépôts :

| | avant | après |
|---|---:|---:|
| dépôts couverts | 22 | **28** |
| shard `rest` | jamais | `["NEURON.click", "Homelab"]` |

Les shards restent disjoints — un dépôt tombe dans exactement un.