### PR TITLE
fix(renovate): résout les crates ferrlabs-* depuis Kellnr

### DIFF
--- a/.github/workflows/renovate-selfcheck.yml
+++ b/.github/workflows/renovate-selfcheck.yml
@@ -1,0 +1,177 @@
+name: Renovate self-check
+
+# Guards the two things that silently broke the ferrlabs-* Kellnr lookups for
+# a month (issue #205) and that nothing else notices:
+#
+#   validate      — the shared preset still parses under the *current* Renovate,
+#                   with no removed/deprecated options. `matchPackagePatterns`
+#                   and `matchDepPatterns` were dropped in Renovate 41 and the
+#                   config kept "working" only because Renovate auto-migrates
+#                   at runtime; --strict turns that into a failure.
+#
+#   kellnr-lookup — a real Renovate run against tests/renovate/fixture, which
+#                   reproduces a product repo's layout (crate under api/, the
+#                   kellnr registry declared in a .cargo/config.toml Renovate
+#                   never reads). Asserts that a ferrlabs-* crate actually
+#                   resolves and produces an update. This is the only check
+#                   that catches a missing allowCustomCrateRegistries or a
+#                   hostRule whose hostType doesn't match the datasource id —
+#                   both of which fail as a WARN plus `no-result`, never as a
+#                   non-zero exit.
+#
+# Runs on any change to the Renovate config, and on a schedule 30 minutes
+# after each sweep so a regression coming from Renovate itself (a datasource
+# change, a registry outage, an expired CARGO_REGISTRIES_KELLNR_TOKEN) shows
+# up as a red run rather than as an absence of PRs.
+
+on:
+  pull_request:
+    paths:
+      - "default.json"
+      - "renovate.json"
+      - "snippets/renovate.json"
+      - "tests/renovate/**"
+      - ".github/workflows/renovate.yml"
+      - ".github/workflows/renovate-selfcheck.yml"
+  schedule:
+    - cron: "30 */6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  # Keep in step with the Renovate bundled by renovatebot/github-action in
+  # renovate.yml — a major here should be raised when that action's major is.
+  # Pinned to a major (not `latest`) so an upstream breaking change surfaces
+  # as a deliberate bump rather than as a surprise red run.
+  RENOVATE_VERSION: "41"
+
+jobs:
+  validate:
+    name: Validate config (strict)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+
+      - name: renovate-config-validator --strict
+        run: |
+          npx --yes --package "renovate@${RENOVATE_VERSION}" \
+            renovate-config-validator --strict \
+            default.json renovate.json snippets/renovate.json
+
+  kellnr-lookup:
+    name: Resolve a ferrlabs-* crate end to end
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Fork PRs get no secrets, so the Kellnr token would be empty and the run
+    # would fail for a reason unrelated to the change. The validate job above
+    # still covers them.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+
+      - name: Fail fast if the Kellnr token is missing
+        env:
+          CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
+        run: |
+          if [ -z "${CARGO_REGISTRIES_KELLNR_TOKEN}" ]; then
+            echo "::error::CARGO_REGISTRIES_KELLNR_TOKEN is not set for this run." \
+                 "Renovate cannot read the private Kellnr sparse index without it."
+            exit 1
+          fi
+
+      # Mirrors the real sweep's Cargo configuration exactly: same registry
+      # URL, same hostRule, same global flag, same shared preset. If any of
+      # them regresses in renovate.yml or default.json, this run stops finding
+      # the update.
+      - name: Run Renovate against the fixture
+        working-directory: tests/renovate/fixture
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_PLATFORM: local
+          RENOVATE_DRY_RUN: full
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REQUIRE_CONFIG: optional
+          RENOVATE_CONFIG_FILE: ${{ github.workspace }}/default.json
+          RENOVATE_ALLOW_CUSTOM_CRATE_REGISTRIES: "true"
+          RENOVATE_CUSTOM_ENV_VARIABLES: |
+            {
+              "CARGO_REGISTRIES_KELLNR_INDEX": "sparse+https://crates.ferrlabs.com/api/v1/crates/",
+              "CARGO_REGISTRIES_KELLNR_TOKEN": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}",
+              "CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS": "cargo:token"
+            }
+          RENOVATE_HOST_RULES: |
+            [
+              {
+                "matchHost": "crates.ferrlabs.com",
+                "hostType": "crate",
+                "token": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
+              }
+            ]
+        # Redirected, not tee'd: at LOG_LEVEL=debug Renovate echoes its
+        # resolved config, and the Kellnr token appears there verbatim (it is
+        # not among the fields it sanitizes). Actions would mask it on the way
+        # out, but there is no reason to push it through the job log at all.
+        # The assert step below surfaces the lines that matter.
+        run: |
+          npx --yes --package "renovate@${RENOVATE_VERSION}" renovate \
+            > "${RUNNER_TEMP}/renovate.log" 2>&1
+
+      # always(), so that a Renovate run which exits non-zero still reports
+      # *why* rather than leaving a step that swallowed its own output.
+      - name: Assert the crate resolved
+        if: always()
+        env:
+          LOG: ${{ runner.temp }}/renovate.log
+        run: |
+          set -euo pipefail
+          fail=0
+
+          if [ ! -s "${LOG}" ]; then
+            echo "::error::Renovate produced no log — the run did not start."
+            exit 1
+          fi
+
+          if grep -qE 'Failed to look up crate package ferrlabs-' "${LOG}"; then
+            echo "::error::A ferrlabs-* crate lookup returned no-result." \
+                 "Kit releases are not reaching the product repos — see issue #205."
+            grep -E 'Failed to look up crate package ferrlabs-' "${LOG}" | sort -u
+            fail=1
+          fi
+
+          if grep -q 'allowCustomCrateRegistries=true is required' "${LOG}"; then
+            echo "::error::The crate datasource refused crates.ferrlabs.com." \
+                 "RENOVATE_ALLOW_CUSTOM_CRATE_REGISTRIES must be set in renovate.yml."
+            fail=1
+          fi
+
+          # The positive assertion. The fixture pins ferrlabs-queue to 0.1.0,
+          # which is the oldest published version, so a working lookup always
+          # yields at least one update. Its absence means the dep was skipped,
+          # unresolved, or filtered out by a packageRule.
+          if ! grep -qE 'flattened updates found:.*ferrlabs-queue' "${LOG}"; then
+            echo "::error::No update was proposed for ferrlabs-queue." \
+                 "The lookup did not resolve against the Kellnr sparse index."
+            grep -E 'ferrlabs-queue|skipReason' "${LOG}" | tail -20 || true
+            fail=1
+          fi
+
+          if [ "${fail}" -ne 0 ]; then
+            exit 1
+          fi
+          echo "ok — ferrlabs-queue resolves from crates.ferrlabs.com and an update was found"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -189,6 +189,17 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: ${{ matrix.filter }}
           RENOVATE_PLATFORM: "github"
           RENOVATE_REPOSITORY_CACHE: "enabled"
+          # REQUIRED for the private Kellnr registry. The crate datasource
+          # hard-refuses any registry whose host isn't index.crates.io unless
+          # this is set — it bails out before issuing a single request
+          # (`registry.flavor !== 'crates.io' && !GlobalConfig.get(...)` in
+          # modules/datasource/crate). Every ferrlabs-* lookup then reports
+          # `no-result`, which reads like a missing crate rather than a config
+          # gate, and no Kit update is ever proposed. It is a globalOnly
+          # option, so it cannot live in default.json (that file is also
+          # consumed as a shared preset by every repo, where global options
+          # are rejected) — it has to come from the environment here.
+          RENOVATE_ALLOW_CUSTOM_CRATE_REGISTRIES: "true"
           # Private Kellnr cargo registry, needed so Renovate's `cargo update`
           # lockfile runs resolve it. The registry lives in each repo's
           # api/.cargo/config.toml, but Renovate invokes cargo from the repo root
@@ -239,6 +250,13 @@ jobs:
           # The github-tags / git-refs hostRules below keep the App token for
           # cross-repo octokit calls (release notes) and the git-refs datasource
           # fetching FerrLabs/Kit refs/heads/main.
+          #
+          # `hostType` must be a *datasource* id, never a manager id: hostRules
+          # are matched with a plain `search.hostType === rule.hostType`, and
+          # the datasource sets it from its own id. The Cargo one is `crate`
+          # (CrateDatasource.id) — `cargo` is the manager and matches nothing,
+          # so the Kellnr rule silently contributed no token and the sparse
+          # index answered 401, surfacing as the same `no-result` as above.
           RENOVATE_HOST_RULES: |
             [
               {
@@ -258,7 +276,7 @@ jobs:
               },
               {
                 "matchHost": "crates.ferrlabs.com",
-                "hostType": "cargo",
+                "hostType": "crate",
                 "token": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
               }
             ]

--- a/default.json
+++ b/default.json
@@ -44,9 +44,9 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "FerrLabs npm packages — trust them, scan often, merge without delay. Override registry to GHCR (npm.pkg.github.com) since these packages aren't on npmjs.org. Auth comes from RENOVATE_HOST_RULES env in the runner workflow. internalChecksFilter:none skips the stability-days gate inherited from the global default.",
-      "matchPackagePatterns": [
-        "^@ferrlabs/"
+      "description": "FerrLabs npm packages — trust them, scan often, merge without delay. Override registry to GHCR (npm.pkg.github.com) since these packages aren't on npmjs.org. Auth comes from RENOVATE_HOST_RULES env in the runner workflow. internalChecksFilter:none skips the stability-days gate inherited from the global default. In practice this rule is belt-and-braces for the registry: each consuming repo's `.npmrc` already carries `@ferrlabs:registry=https://npm.pkg.github.com`, so the lookup resolves without it — the rule is what supplies the automerge/schedule policy.",
+      "matchPackageNames": [
+        "/^@ferrlabs\\//"
       ],
       "registryUrls": [
         "https://npm.pkg.github.com"
@@ -80,12 +80,12 @@
       "groupName": "FerrLabs Kit"
     },
     {
-      "description": "FerrLabs Cargo crates published from Kit (`ferrlabs-*`) — same trust as @ferrlabs/ npm packages. No wait, automerge. registryUrls is required: these deps declare `registry = \"kellnr\"`, which Renovate resolves through `.cargo/config.toml` — but that file lives in each repo's `api/` subdirectory and is not discovered, so the lookup fails with `registry index was not found: kellnr` and no update is ever proposed. Pointing registryUrls at the sparse index bypasses that resolution, the same way the @ferrlabs/ npm rule overrides its registry. Auth comes from the crates.ferrlabs.com hostRule in renovate.yml.",
+      "description": "FerrLabs Cargo crates published from Kit (`ferrlabs-*`) — same trust as @ferrlabs/ npm packages. No wait, automerge. registryUrls is a fallback: these deps declare `registry = \"kellnr\"`, which the cargo manager resolves from `.cargo/config.toml` relative to the repo root — but that file lives in each repo's `api/` subdirectory and is not discovered, so the dep would be skipped as `unknown-registry`. In practice the runner supplies CARGO_REGISTRIES_KELLNR_INDEX via RENOVATE_CUSTOM_ENV_VARIABLES, which the extractor reads first (getCargoIndexEnv); registryUrls here covers the case where that env is missing. Note that neither is sufficient on its own: the crate datasource refuses every non-crates.io registry unless allowCustomCrateRegistries=true, which is a global-only option set as RENOVATE_ALLOW_CUSTOM_CRATE_REGISTRIES in renovate.yml. Auth comes from the crates.ferrlabs.com hostRule there, which must use hostType `crate` (the datasource id) — `cargo` is the manager id and matches no hostRule.",
       "matchManagers": [
         "cargo"
       ],
-      "matchDepPatterns": [
-        "^ferrlabs-"
+      "matchDepNames": [
+        "/^ferrlabs-/"
       ],
       "registryUrls": [
         "sparse+https://crates.ferrlabs.com/api/v1/crates/"
@@ -105,8 +105,8 @@
       "matchManagers": [
         "npm"
       ],
-      "excludePackagePatterns": [
-        "^@ferrlabs/"
+      "matchPackageNames": [
+        "!/^@ferrlabs\\//"
       ],
       "matchUpdateTypes": [
         "patch",
@@ -122,8 +122,8 @@
       "matchManagers": [
         "cargo"
       ],
-      "excludeDepNames": [
-        "/^ferrlabs-/"
+      "matchDepNames": [
+        "!/^ferrlabs-/"
       ],
       "matchUpdateTypes": [
         "patch",
@@ -191,8 +191,8 @@
     {
       "customType": "regex",
       "description": "FerrLabs Kit crates pinned via git rev = ... in Cargo.toml. Tracks the HEAD of `main` via the git-refs datasource — Kit publishes per-crate tags (ferrlabs-types-v0.4.0 etc.), not a single repo-wide semver tag, so github-tags doesn't fit. git-refs returns the SHA of refs/heads/main and Renovate bumps the rev= to it.",
-      "fileMatch": [
-        "(^|/)Cargo\\.toml$"
+      "managerFilePatterns": [
+        "/(^|/)Cargo\\.toml$/"
       ],
       "matchStrings": [
         "ferrlabs-[a-z\\-]+\\s*=\\s*\\{\\s*git\\s*=\\s*\"https://github.com/FerrLabs/Kit\\.git\"\\s*,\\s*rev\\s*=\\s*\"(?<currentDigest>[a-f0-9]+)\"\\s*\\}"

--- a/tests/renovate/README.md
+++ b/tests/renovate/README.md
@@ -1,0 +1,38 @@
+# Renovate self-check fixture
+
+`fixture/` is a minimal repository that reproduces the shape of a FerrLabs
+product repo, as far as Renovate is concerned:
+
+- the crate manifest lives in `api/Cargo.toml`, not at the root;
+- `api/.cargo/config.toml` declares the `kellnr` registry, which Renovate's
+  cargo manager does **not** discover (it reads `.cargo/config.toml` relative
+  to the repo root);
+- one dependency is pinned to a deliberately stale `ferrlabs-*` version.
+
+`.github/workflows/renovate-selfcheck.yml` runs Renovate against it with
+`--platform=local` and the same configuration the real sweep uses, then
+asserts that the crate resolves and that an update is proposed.
+
+This exists because the `ferrlabs-*` lookups silently returned `no-result`
+for over a month (issue #205): Kit shipped 2.x while the products stayed on
+0.x, so security fixes in `ferrlabs-auth` / `ferrlabs-permissions` reached
+nobody. Nothing failed — Renovate logged a `WARN` and carried on. The three
+independent causes were all invisible to config validation:
+
+1. `allowCustomCrateRegistries` unset, so the crate datasource refused the
+   registry before making a request;
+2. the Kellnr `hostRule` used `hostType: cargo` (a manager id) instead of
+   `crate` (the datasource id), so no token was attached and the sparse index
+   answered 401;
+3. `matchDepPatterns` / `matchPackagePatterns` were removed in Renovate 41.
+
+Only an end-to-end lookup catches (1) and (2). The `validate` job in the same
+workflow catches (3) and anything else `renovate-config-validator --strict`
+knows about.
+
+## Updating the fixture
+
+Keep `ferrlabs-queue` pinned to a version that is **older** than the latest
+published one — the check asserts that an update is found, so pinning it to
+the current release would make the check pass vacuously. `0.1.0` is the
+oldest published version and never needs bumping.

--- a/tests/renovate/fixture/api/.cargo/config.toml
+++ b/tests/renovate/fixture/api/.cargo/config.toml
@@ -1,0 +1,8 @@
+# Copy of the .cargo/config.toml every product repo carries under api/.
+# Renovate's cargo manager looks for .cargo/config.toml from the repo root,
+# so it never reads this file — which is exactly the condition under test.
+[registries.kellnr]
+index = "sparse+https://crates.ferrlabs.com/api/v1/crates/"
+
+[registry]
+global-credential-providers = ["cargo:token"]

--- a/tests/renovate/fixture/api/Cargo.toml
+++ b/tests/renovate/fixture/api/Cargo.toml
@@ -1,0 +1,11 @@
+# Fixture manifest — see ../../README.md. Mirrors a product repo: the crate
+# lives under api/, and ferrlabs-queue is pinned to the oldest published
+# version so the self-check can assert that an update is proposed.
+[package]
+name = "renovate-selfcheck-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ferrlabs-queue = { version = "0.1.0", registry = "kellnr" }


### PR DESCRIPTION
Corrige #205.

## Cause racine

Trois défauts indépendants, aucun ne produisant un échec :

1. **`allowCustomCrateRegistries` jamais activé** — c'est la cause principale. Le datasource `crate` refuse tout registre dont l'hôte n'est pas `index.crates.io` tant que ce drapeau est faux, et il abandonne *avant* la moindre requête HTTP (`registry.flavor !== 'crates.io' && !GlobalConfig.get(...)`). Chaque lookup `ferrlabs-*` ressort en `no-result`, ce qui se lit comme un crate absent plutôt que comme un verrou de configuration. C'est une option `globalOnly` : elle ne peut pas vivre dans `default.json`, qui est aussi consommé comme preset partagé par chaque repo.

2. **`hostType: "cargo"` dans la hostRule Kellnr** — les hostRules se comparent par égalité stricte avec le `hostType` que pose le datasource, c'est-à-dire son propre id : `crate`. `cargo` est l'id du *manager* et ne correspond à rien. Le jeton n'était donc jamais joint et l'index sparse répondait 401 — même symptôme `no-result`.

3. **Options retirées en Renovate 41** — `matchPackagePatterns`, `matchDepPatterns`, `excludePackagePatterns`, `excludeDepNames`, `fileMatch`. Migrées ici. À noter : ce n'était **pas** la cause, contrairement à la piste de l'issue — Renovate migre ces options à l'exécution et le matcher `ferrlabs-*` s'appliquait bien.

## Vérification

Reproduit et corrigé de bout en bout avec un vrai run Renovate contre une fixture reproduisant la disposition d'un repo produit :

- config actuelle → `WARN: crate datasource: allowCustomCrateRegistries=true is required […] bailing out` puis `Failed to look up crate package ferrlabs-queue: no-result`
- `allowCustomCrateRegistries=true` seul, `hostType: cargo` → `GET .../fe/rr/ferrlabs-queue = 401` puis `no-result`
- les deux correctifs → `newValue: "2.0.0"` pour `ferrlabs-queue` (épinglé 0.1.0)

## Garde anti-régression

`.github/workflows/renovate-selfcheck.yml`, sur PR touchant la config Renovate et toutes les 6 h, 30 min après le sweep :

- `validate` — `renovate-config-validator --strict` sur les trois fichiers de config ; attrape le point 3 et tout futur retrait d'option.
- `kellnr-lookup` — rejoue un vrai lookup Renovate contre `tests/renovate/fixture` et échoue si aucune mise à jour `ferrlabs-*` n'est proposée. C'est le seul contrôle qui attrape les points 1 et 2, qui ne se manifestent que par un `WARN` et un `no-result`, jamais par un code de sortie.

Les deux cas ont été testés localement : la garde passe avec le correctif et échoue sans (`updates=1 failures=0` contre `updates=0 failures=2`).

## Après merge

La première passe ouvrira le rattrapage d'un coup — `ferrlabs-auth` 0.3.3 → 2.2.1, `ferrlabs-permissions` 0.2.0 → 2.1.1, `ferrlabs-queue` 0.1.0 → 2.1.1, `ferrlabs-cache` 0.5 → 2.0.0. Ce sont des majeures, donc en revue manuelle (règle « Major updates — always manual »), pas en automerge.