### PR TITLE
feat(renovate): pas de délai sur nos propres actions et reusables

### DIFF
--- a/default.json
+++ b/default.json
@@ -149,6 +149,18 @@
       "groupName": "GitHub Actions"
     },
     {
+      "description": "Actions et workflows réutilisables maison — pas de délai, pas d'attente du lundi. La règle précédente fait patienter 3 jours parce que les auteurs tiers re-taguent après publication ; sur nos propres dépôts ce risque n'existe pas, on contrôle le contenu et le SHA. Sans cette exception, un changement dans FerrLabs/.github met jusqu'à quatre jours à atteindre les dépôts consommateurs (schedule lundi + 3 jours d'âge), ce qui bloque toute bascule coordonnée. `FerrLabs/.github` est nommé explicitement : un glob minimatch n'attrape pas un segment commençant par un point.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["FerrLabs/.github", "FerrLabs/**"],
+      "schedule": ["at any time"],
+      "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrLabs actions"
+    },
+    {
       "description": "Dockerfile base images — wait 3 days, grouped + auto-merge weekly",
       "matchManagers": [
         "dockerfile"


### PR DESCRIPTION
Nos workflows réutilisables mettent jusqu'à **quatre jours** à atteindre les dépôts qui les consomment. Ce n'est pas un bug : c'est la règle `github-actions` du preset, qui s'applique aussi à nos propres dépôts.

## Ce qui bloquait

```json
{
  "matchManagers": ["github-actions"],
  "schedule": ["before 6am on monday"],
  "minimumReleaseAge": "3 days"
}
```

Deux verrous, chacun suffisant. Un changement poussé un samedi attend lundi 6 h **et** trois jours d'âge — donc mardi.

Le motif d'origine est bon : *« action authors often re-tag »*. Mais il vise les auteurs tiers. Sur `FerrLabs/*` nous contrôlons le contenu et le SHA ; le risque de re-tag silencieux n'existe pas.

## Ce que ça a coûté aujourd'hui

`.github#206` monte l'épinglage FerrFlow vers v6.1.0. Tant qu'il n'a pas atteint les 18 dépôts consommateurs, le retrait des montages `/v1` (FerrLabs/FerrFlow-Cloud#788) casserait leur chaîne de release. Ce retrait attend donc mardi, pour une raison purement calendaire.

## La règle

Placée **après** la règle générale — dans Renovate, la plus tardive gagne sur ce qu'elle redéfinit. Elle lève le `schedule`, l'âge minimum et le filtre de stabilité pour `FerrLabs/*` uniquement ; tout le reste garde ses trois jours.

## Un détail qui aurait rendu la règle inerte

`FerrLabs/.github` est **nommé explicitement** en plus du glob :

```json
"matchPackageNames": ["FerrLabs/.github", "FerrLabs/**"]
```

Les globs minimatch n'attrapent pas un segment commençant par un point sans l'option `dot`. `FerrLabs/**` seul aurait donc ignoré précisément le dépôt qui motive ce changement — la règle aurait été validée, appliquée, et sans effet.

## Vérifié

```console
$ npx --package renovate -c "renovate-config-validator default.json"
INFO: Config validated successfully against 1 file(s)
```

12 lignes ajoutées, aucune autre touchée.

## Au passage

Le run Renovate signale `WARN: Config needs migrating` sur `matchPackagePatterns` (règle `^@ferrlabs/`), syntaxe dépréciée que Renovate migre encore à la volée. Elle fonctionne, mais mérite d'être modernisée avant qu'une version la retire. Volontairement hors périmètre ici.