### PR TITLE
chore(renovate): add Docker-Runners to the infra shard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -111,7 +111,7 @@ jobs:
             --argjson repos "${repos}" \
             --argjson tools '["FerrFlow","FerrVault","Benchmarks","Fixtures",".github","MCP","Changelog","Status"]' \
             --argjson libs  '["Claude-Agents","actions-runner-image","UI","Kit"]' \
-            --argjson infra '["Infra","Kubernetes"]' \
+            --argjson infra '["Infra","Kubernetes","Docker-Runners"]' \
             --argjson games '["FerrGames-Discord","ArchVeil","RogueLite","Idler-Survivor"]' '
             def flt($xs): [$xs[] | "FerrLabs/" + .] | join(",");
             ($tools + $libs + $infra + $games) as $named


### PR DESCRIPTION
`FerrLabs/Docker-Runners` holds the overflow runner pool that runs under Docker Compose on a workstation and registers with the same `ferrlabs-k8s` / `ferrlabs-k8s-large` labels as the ARC scale sets.

Without this it falls into the `rest` catch-all. Grouping it with `Infra` and `Kubernetes` keeps the infra repos in one Renovate leg — same domain, same review posture, and its `compose.yaml` pins the same class of images the cluster manifests do.

Also corrects the comment above `runs-on: ubuntu-latest`, which called `ferrlabs-k8s` a group. It is a label; the group is `ferrlabs-runner` (FerrLabs/Kubernetes#146) and governs something else entirely — which repositories may use the runners, not which tier a job lands on. The two shared a name until now, and that comment lives in the same file as this change, so it rides along rather than racing a second branch on the same lines.

Closes #211