### PR TITLE
fix(ci): scan private repos by default and fail when every scan job is skipped

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -81,10 +81,20 @@ on:
         required: false
         default: ''
       run-on-private:
-        description: 'Set to `true` to run the scans on private repos too. Defaults to `false` because GitHub-hosted runners consume billed minutes on private repos and our security scans are best-effort hygiene, not blocking gates. Public repos always run (Actions are free for them).'
+        description: >-
+          Run the scans on private repos. Defaults to `true` since #202: it
+          used to default to `false` to avoid burning billed GitHub-hosted
+          minutes, but private repos now land on the self-hosted
+          `ferrlabs-k8s*` pool, so there is nothing left to save. Opting out
+          per repo was the wrong shape — six repos, including `Kit` and
+          `Infra`, sat unscanned while their runs reported green, and the
+          count grew with every new private repo.
+
+          Set to `false` to deliberately skip a private repo. The `scanned`
+          job then fails, so the opt-out is visible rather than silent.
         type: boolean
         required: false
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -402,3 +412,37 @@ jobs:
           sarif_file: snyk.sarif
           category: snyk
         continue-on-error: true
+
+  # The reason #202 sat open for as long as it did: when the private gate
+  # blocked every job, the workflow still reported success. A skipped run and
+  # a clean run were indistinguishable in the UI, in the checks API, and in
+  # branch protection. This job is the difference.
+  #
+  # trufflehog is excluded on purpose — it is additionally gated on
+  # schedule/workflow_dispatch, so it legitimately skips on push and PR, and
+  # counting it would fire this on every ordinary run.
+  scanned:
+    name: Scans ran
+    needs: [gitleaks, osv-scanner, opengrep, zizmor, snyk]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Assert the scan jobs were not all skipped
+        env:
+          RESULTS: ${{ needs.gitleaks.result }} ${{ needs.osv-scanner.result }} ${{ needs.opengrep.result }} ${{ needs.zizmor.result }} ${{ needs.snyk.result }}
+          IS_PRIVATE: ${{ github.event.repository.private }}
+        run: |
+          set -euo pipefail
+          ran=0
+          for r in ${RESULTS}; do
+            [ "${r}" = "skipped" ] || ran=$((ran + 1))
+          done
+
+          if [ "${ran}" -eq 0 ]; then
+            echo "::error::Every security scan job was skipped — this repository is not being scanned." \
+                 "private=${IS_PRIVATE}. If that is deliberate, say so in the caller;" \
+                 "otherwise remove \`run-on-private: false\`. See FerrLabs/.github#202."
+            exit 1
+          fi
+          echo "ok — ${ran}/5 scan jobs ran (results: ${RESULTS})"


### PR DESCRIPTION
Closes #202.

Two changes to `reusable-security-scan.yml`, matching points 1 and 2 of the issue's suggested fix.

**`run-on-private` now defaults to `true`.** The `false` default existed to avoid burning billed GitHub-hosted minutes; private repos now land on the self-hosted `ferrlabs-k8s*` pool, so there is nothing left to save. It stays available as a deliberate opt-out.

**New terminal `scanned` job.** This is the part that made #202 survivable for as long as it did: when the gate blocked every job the workflow still reported success, so an unscanned repo and a clean one were indistinguishable in the UI, in the checks API, and in branch protection. The job runs `if: always()`, counts how many of the five always-eligible jobs were skipped, and fails when the answer is all of them.

`trufflehog` is excluded from the count on purpose — it carries a second gate on `schedule`/`workflow_dispatch`, so it legitimately skips on push and PR. Counting it would fire the guard on every ordinary run.

## Point 3 deliberately not done

The issue also suggested setting `run-on-private: true` in the affected callers as a stopgap. With the default flipped that is dead config, and @BryanFRD's comment makes the argument better than I can: `FerrGames-Discord` was created *after* the issue was filed and inherited the same silence. Per-repo opt-in is the shape that produced the bug. The eight callers that already pass `run-on-private: true` are now redundant too — harmless, and not worth eight PRs of churn to remove.

## This does not turn anyone's CI red

Every `fail-on-*` input defaults to `false`, so newly-scanned repos surface findings as SARIF in the Security tab and warnings in the log, without failing the build. Expect a burst of new alerts on `Kit`, `Infra`, `UI`, `FerrGames-Cloud`, `Status` and `FerrGames-Discord` — six repos, six jobs each, scanning for the first time.

The one real operational risk is pool load rather than red builds: ~30 additional jobs per sweep landing on `ferrlabs-k8s` / `ferrlabs-k8s-light`.

## It is not instant

All six repos pin this workflow by SHA (five on `d3ce80b`, `FerrGames-Discord` on `b6c0dc1`), so nothing changes until Renovate bumps each pin. The `FerrLabs actions` rule in `default.json` runs `at any time` with `minimumReleaseAge: 0` and automerge, so that should land within a sweep — worth confirming rather than assuming.

## Verified

The workflow parses (7 jobs now), and the guard's shell was exercised against the four cases that matter:

```
skipped ×5              → error, exit 1   (the #202 bug)
success ×5              → ok, 5/5 ran
failure + success ×4    → ok, 5/5 ran     (a failing scan is not a skipped one)
success ×4 + skipped    → ok, 4/5 ran     (snyk quota, say, must not trip it)
```

`permissions: {}` on the new job — it reads job results and nothing else.