### PR TITLE
fix(ci): accorde pull-requests write au job sonarqube des reusables

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -209,6 +209,20 @@ jobs:
     # build/lint regardless of their result.
     if: inputs.enable-sonar && !cancelled()
     needs: build
+    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
+    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
+    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
+    # l'appel imbrique a reusable-sonarqube-scan, qui demande
+    # `pull-requests: write`, fait echouer le run entier au demarrage --
+    # startup_failure, sans job ni message exploitable. Pose au niveau job et
+    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
+    # restent en lecture seule.
+    # L'appelant doit accorder la meme permission sur le job qui appelle ce
+    # workflow, sinon il n'y a rien a transmettre.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     uses: FerrLabs/.github/.github/workflows/reusable-sonarqube-scan.yml@d4e229f4fd57b20a53016514e61e3bf9e53dfc7e # main
     with:
       runner: ${{ inputs.runner }}

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -265,6 +265,19 @@ jobs:
     if: inputs.enable-sonar && !cancelled()
     # needs: test so the coverage artifact exists before the scan downloads it.
     needs: test
+    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
+    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
+    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
+    # l'appel imbrique a reusable-sonarqube-scan, qui demande
+    # `pull-requests: write`, fait echouer le run entier au demarrage --
+    # startup_failure, sans job ni message exploitable. Pose au niveau job et
+    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
+    # restent en lecture seule.
+    # L'appelant doit accorder la meme permission sur le job qui appelle ce
+    # workflow, sinon il n'y a rien a transmettre.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: FerrLabs/.github/.github/workflows/reusable-sonarqube-scan.yml@d4e229f4fd57b20a53016514e61e3bf9e53dfc7e # main
     with:
       runner: ${{ inputs.runner }}

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -282,6 +282,20 @@ jobs:
     if: inputs.enable-sonar && !cancelled()
     # needs: test so the coverage artifact exists before the scan downloads it.
     needs: test
+    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
+    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
+    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
+    # l'appel imbrique a reusable-sonarqube-scan, qui demande
+    # `pull-requests: write`, fait echouer le run entier au demarrage --
+    # startup_failure, sans job ni message exploitable. Pose au niveau job et
+    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
+    # restent en lecture seule.
+    # L'appelant doit accorder la meme permission sur le job qui appelle ce
+    # workflow, sinon il n'y a rien a transmettre.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     uses: FerrLabs/.github/.github/workflows/reusable-sonarqube-scan.yml@d4e229f4fd57b20a53016514e61e3bf9e53dfc7e # main
     with:
       runner: ${{ inputs.runner }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -571,6 +571,19 @@ jobs:
     # for full reports.
     if: inputs.enable-sonar && !cancelled()
     needs: coverage
+    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
+    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
+    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
+    # l'appel imbrique a reusable-sonarqube-scan, qui demande
+    # `pull-requests: write`, fait echouer le run entier au demarrage --
+    # startup_failure, sans job ni message exploitable. Pose au niveau job et
+    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
+    # restent en lecture seule.
+    # L'appelant doit accorder la meme permission sur le job qui appelle ce
+    # workflow, sinon il n'y a rien a transmettre.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: FerrLabs/.github/.github/workflows/reusable-sonarqube-scan.yml@d4e229f4fd57b20a53016514e61e3bf9e53dfc7e # main
     with:
       runner: ${{ inputs.runner }}


### PR DESCRIPTION
Le job `sonarqube` de `reusable-ci-{rust,go,node,astro}` déclare désormais `pull-requests: write`.

Sans cette ligne, ces workflows plafonnent à `contents: read` et coupent la permission avant qu'elle n'atteigne l'appel imbriqué à `reusable-sonarqube-scan`, qui la demande depuis #198. GitHub refuse alors de démarrer le run : `startup_failure`, aucun job créé, aucun message exploitable par l'API — d'où la difficulté à diagnostiquer.

La permission est posée au niveau **job**, pas du workflow : seul le job qui commente le delta sur les PR obtient l'écriture, les jobs de build restent en lecture seule.

**Ce PR ne suffit pas à lui seul.** Chaque repo consommateur doit accorder la même permission sur le job qui appelle ces workflows — sinon il n'y a rien à transmettre. Vérifié dans les deux sens : appelant seul → échoue ; intermédiaire seul → échoue ; les deux → démarre. Les PR consommateurs suivent.

Closes #216
