### PR TITLE
ci: valide le titre des PR selon Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional:
+    name: Conventional commits
+    runs-on: ferrlabs-k8s-light
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            chore
+            style
+            test
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^[A-Za-z].+$
+          subjectPatternError: |
+            Subject "{subject}" must start with an uppercase or lowercase letter and not be empty.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,12 @@
 name: PR title
 
+# `pull_request_target` est délibéré et sûr ici : le job ne fait aucun
+# `checkout`, n'exécute donc rien qui vienne de la PR, et ne lit que le titre
+# dans la charge utile de l'événement avec `pull-requests: read`. C'est aussi ce
+# qui empêche une PR de fork d'affaiblir sa propre validation en modifiant ce
+# fichier, ce que `pull_request` autoriserait.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
Ajoute la validation du titre de PR, absente de ce dépôt.

Ce n'est pas cosmétique ici : le titre de la PR devient le message de commit sur `main` lors d'un squash-merge, et **FerrFlow en déduit le bump de version**. Un titre mal formé produit donc silencieusement une mauvaise version — ou aucune.

Le fichier est identique à celui des dix-neuf autres dépôts qui l'ont déjà, y compris le palier `ferrlabs-k8s-light` : une regex sur une chaîne n'a pas besoin d'un runner 2 CPU.

L'audit de l'organisation trouvait dix dépôts sans cette validation. Cinq comptent, ceux où FerrFlow coupe des versions ; les cinq autres sont des prototypes et restent tels quels.
