### PR TITLE
chore(renovate): gate lockFileMaintenance behind release age and manual review

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,11 +13,11 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "lockFileMaintenance": {
+    "description": "Refresh lockfiles weekly. This is the one path that bypasses the npm quarantine below: lock file maintenance resolves every transitive dep to whatever the registry serves at that moment, and minimumReleaseAge is not reliably applied to this update type — so a package republished with a malicious version (keyv/cacheable, 2026-08-04) could land here hours after publication. Two gates: the release age is declared explicitly in case the manager does honour it, and automerge is off so the refreshed lockfile is always reviewed by a human before it reaches main.",
     "enabled": true,
     "schedule": ["before 6am on monday"],
-    "automerge": true,
-    "automergeType": "pr",
-    "automergeStrategy": "squash"
+    "minimumReleaseAge": "3 days",
+    "automerge": false
   },
   "labels": [
     "dependencies"


### PR DESCRIPTION
`lockFileMaintenance` était le seul chemin contournant la quarantaine npm de 3 jours : il résout chaque dépendance transitive vers ce que le registre sert à l'instant T, et `minimumReleaseAge` n'est pas appliqué de façon fiable à ce type de mise à jour. Combiné à `automerge: true`, une version republiée malicieusement (keyv/cacheable, 2026-08-04) pouvait atterrir sur main sans relecture.

Deux garde-fous :
- `minimumReleaseAge: "3 days"` déclaré explicitement, aligné sur la règle npm tiers
- `automerge: false` — le lockfile rafraîchi passe par une relecture humaine

Impact : une PR hebdomadaire par repo à merger manuellement au lieu d'un automerge silencieux.