### PR TITLE
docs(profile): liste tous les produits avec une description simple

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,65 +4,62 @@
 
 **Developer tools for teams that ship.**
 
-[ferrlabs.com](https://ferrlabs.com) · [ferrflow.com](https://ferrflow.com)
+[ferrlabs.com](https://ferrlabs.com) · [status](https://status.ferrlabs.com) · [changelog](https://ferrlabs.com/changelog)
 
 </div>
 
 ---
 
-We build small, opinionated CLIs and self-hostable backends for the parts of the dev workflow you should not have to think about. Open source where it makes sense, paid SaaS or self-host when you need more.
+We build small, opinionated tools for the parts of the dev workflow you should not have to think about. One org, one login, one bill across every product — and FerrFlow stays free inside all of them.
+
+## Products
+
+| Product | What it does | |
+|---|---|---|
+| **FerrFlow** | Releases your code. Reads your conventional commits, bumps the version, writes the changelog, tags and publishes — one binary, any language. | [ferrflow.com](https://ferrflow.com) |
+| **FerrVault** | Stores your secrets and hands them to your apps, without running the infrastructure yourself. | [ferrvault.com](https://ferrvault.com) |
+| **FerrTrack** | Tracks your issues. A keyboard-first, git-aware tracker for product teams — no SLAs or AI summaries you didn't ask for. | [ferrtrack.com](https://ferrtrack.com) |
+| **FerrGrowth** | Builds and ships your marketing site: pages, forms, SEO audits, analytics. | [ferrgrowth.com](https://ferrgrowth.com) |
+| **FerrFleet** | Runs your AI agents and shows you what they actually did — execution plus observability. | [ferrfleet.com](https://ferrfleet.com) |
+| **FerrLens** | Checks your stack. Free standalone tools for SEO, DNS, email (SPF/DKIM/DMARC), TLS, and everyday dev chores. | [ferrlens.com](https://ferrlens.com) |
+| **FerrGames** | Small multiplayer party games to play with friends. In the browser, no account needed. | [ferrgames.com](https://ferrgames.com) |
 
 ## Open source
 
-### [FerrFlow](https://github.com/FerrLabs/FerrFlow) · v5
+### [FerrFlow](https://github.com/FerrLabs/FerrFlow) · v7 · MPL-2.0
 
-Universal semantic versioning. One Rust binary reads your conventional commits, bumps versions across your monorepo (14+ file formats — Cargo.toml, package.json, pyproject.toml, Chart.yaml, mix.exs, gemspec, pubspec.yaml, …), generates changelogs, tags, and ships GitHub releases. Free, MPL-2.0, drop into any CI.
+Universal semantic versioning. One Rust binary reads your conventional commits, bumps versions across your monorepo (14+ file formats — `Cargo.toml`, `package.json`, `pyproject.toml`, `Chart.yaml`, `mix.exs`, gemspec, `pubspec.yaml`, …), generates changelogs, tags, and ships GitHub releases. Drop it into any CI.
 
 ```bash
 cargo install ferrflow
 # or
-uses: FerrLabs/FerrFlow@v5
+uses: FerrLabs/FerrFlow@v7
 ```
 
 → [Docs & playground at ferrflow.com](https://ferrflow.com)
 
 ### [FerrVault Operator](https://github.com/FerrLabs/FerrVault)
 
-Kubernetes operator (Go) that syncs FerrVault SaaS secrets into native `kind: Secret`. Two CRDs — `FerrVaultConnection` + `FerrVaultSecret`. Pairs with the FerrVault SaaS but works equally well against a self-hosted FerrVault.
+Kubernetes operator (Go) that syncs FerrVault secrets into native `kind: Secret`. Two CRDs — `FerrVaultConnection` and `FerrVaultSecret`. Pairs with FerrVault SaaS, works just as well against a self-hosted instance.
+
+### [MCP](https://github.com/FerrLabs/MCP)
+
+Model Context Protocol server. Lets AI assistants drive the suite — cut a release, read issues, manage secrets, query analytics.
 
 ### Tooling around FerrFlow
 
-- **[Fixtures](https://github.com/FerrLabs/Fixtures)** — declarative git fixture generator. Spin up reproducible repos in CI for integration tests and benchmarks.
+- **[Fixtures](https://github.com/FerrLabs/Fixtures)** — declarative git fixture generator. Reproducible repos for integration tests and benchmarks.
 - **[Benchmarks](https://github.com/FerrLabs/Benchmarks)** — reusable GitHub Action that runs the FerrFlow perf suite and reports regressions on every PR.
-- **[MCP](https://github.com/FerrLabs/MCP)** — Model Context Protocol server. Lets AI assistants drive the FerrLabs suite — trigger releases, query Kubernetes, read GitHub state.
-
-## The suite
-
-The rest of the toolkit is SaaS. One FerrLabs org, one bill, per-product subscriptions — and FerrFlow stays free inside every org.
-
-| | What | |
-|---|---|---|
-| **FerrVault** | Secrets management without the infra. K8s-native via the [operator](https://github.com/FerrLabs/FerrVault) above. | [ferrvault.com](https://ferrvault.com) |
-| **FerrTrack** | Issue tracker for product teams. Keyboard-first, git-aware, anti-Jira — no SLAs or AI summaries you didn't ask for. | [ferrtrack.com](https://ferrtrack.com) |
-| **FerrGrowth** | Marketing sites with built-in SEO, performance budgets, forms, and analytics. | [ferrgrowth.com](https://ferrgrowth.com) |
-| **FerrFleet** | Agent fleet runtime. AI agents that orchestrate the FerrLabs suite — and a general-purpose agent platform you can actually trust. | [ferrfleet.com](https://ferrfleet.com) |
-| **FerrLens** | Free web tools — SEO checker, DNS lookup, SPF/DKIM/DMARC, TLS analyzer, dev utilities. *See your stack clearly.* | [ferrlens.com](https://ferrlens.com) |
-
-## Also from FerrLabs
-
-- **[FerrGames](https://ferrgames.com)** — small multiplayer party games to play with friends. Free, in the browser, no account needed.
 
 ## Principles
 
 - **CLIs over UIs.** The terminal is the original keyboard shortcut.
-- **Self-host is a feature.** Your data, your cluster, your problem to solve.
+- **Self-host is a feature.** Your data, your cluster.
 - **Open source where it makes sense.** The infra layer should be readable.
 - **No telemetry by default.** Off until you opt in.
 
 ---
 
 <div align="center">
-
-Built in Rust, Go, and TypeScript · MPL-2.0 where applicable · Hand-built in Lille, FR
-
+<sub><a href="https://ferrlabs.com">ferrlabs.com</a> · <a href="mailto:contact@ferrlabs.com">contact@ferrlabs.com</a></sub>
 </div>


### PR DESCRIPTION
## Objectif

Le README d'organisation dispersait les produits sur trois sections (« Open source », « The suite », « Also from FerrLabs ») et en décrivait certains par leur architecture plutôt que par leur usage. Cette PR regroupe **les 7 produits dans un seul tableau**, chacun avec une phrase disant simplement ce qu'il fait.

## Contenu

| Produit | Description retenue |
|---|---|
| FerrFlow | Releases your code — commits conventionnels → version, changelog, tag, publication |
| FerrVault | Stores your secrets and hands them to your apps |
| FerrTrack | Tracks your issues — keyboard-first, git-aware |
| FerrGrowth | Builds and ships your marketing site |
| FerrFleet | Runs your AI agents and shows you what they actually did |
| FerrLens | Checks your stack — SEO, DNS, email, TLS, utilitaires |
| FerrGames | Small multiplayer party games to play with friends |

La section « Open source » est conservée et clarifiée (FerrFlow, l'opérateur FerrVault, MCP, puis Fixtures/Benchmarks comme outillage). Les principes sont inchangés.

## Corrections au passage

- **FerrFlow passe de v5 à v7.** Le README annonçait `uses: FerrLabs/FerrFlow@v5` — deux majeures de retard, la dernière release étant `v7.0.0` (le tag flottant `v7` existe).
- **FerrFleet** était décrit comme « agent fleet runtime … qui orchestre la suite FerrLabs ». Le produit est une plateforme d'exécution **et d'observabilité** d'agents, pas seulement un orchestrateur interne.
- **MCP** remonte au rang de projet open source à part entière plutôt que d'annexe de FerrFlow, et sa description couvre la suite entière.
- Ajout des liens `status` et `changelog` en tête, et de `contact@ferrlabs.com` en pied.

## Vérifications

Les 9 URL citées répondent `200` (les 7 domaines produits, `ferrlabs.com`, `status.ferrlabs.com`) ; `ferrlabs.com/changelog` renvoie un 301 vers sa forme canonique avec barre finale, puis 200. Le tag `v7` de FerrFlow est bien présent sur le dépôt.

## À noter

La description GitHub du dépôt **FerrVault** dit toujours « syncs *FerrFlow* secrets into native Kubernetes Secrets » — elle est périmée, l'opérateur synchronise les secrets *FerrVault*. Elle se modifie dans les réglages du dépôt, hors de cette PR.