### PR TITLE
fix(security-scan): keep the scanned gate off hosted runners on private repos

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -425,7 +425,11 @@ jobs:
     name: Scans ran
     needs: [gitleaks, osv-scanner, opengrep, zizmor, snyk]
     if: always()
-    runs-on: ubuntu-latest
+    # Même sélection que les scans légers : une assertion en shell n'a aucune
+    # raison de coûter une minute facturée de runner hébergé sur un dépôt
+    # privé, alors que tous les autres jobs de ce workflow atterrissent déjà
+    # sur le pool auto-hébergé.
+    runs-on: ${{ inputs.runner != '' && inputs.runner || inputs.light-runner != '' && inputs.light-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     permissions: {}
     steps:
       - name: Assert the scan jobs were not all skipped


### PR DESCRIPTION
Closes #234.

Every job in `reusable-security-scan.yml` selects its runner by repo visibility, so private repos land on the self-hosted `ferrlabs-k8s*` pool. Except one:

```yaml
  scanned:
    name: Scans ran
    if: always()
    runs-on: ubuntu-latest
```

So on every private repo, every pull request and every daily cron spins up a GitHub-hosted runner to run a shell loop that counts five strings. GitHub bills private-repo hosted usage rounded up to the minute per job, so a three-second assertion costs a full billed minute, on every run, on every private repo in the org — `Kit`, `Infra`, `UI`, `FerrGames-Cloud`, `FerrGames-Discord`, `Status` and each new one.

It also queues behind hosted-runner availability, which is why it shows up as "Job is waiting for a hosted runner to come online" long after the actual scans have finished on our own pool.

Nothing about the job needs a hosted runner: no container, no network, no credentials, `permissions: {}`. It should use the same `light-runner` selection as `gitleaks`, `zizmor` and `osv-scanner`.

Worth noting what this is *not*: the scans themselves are already correct. #202 flipped `run-on-private` to `true` precisely because private repos stopped costing hosted minutes. This one job was left behind.

Same expression as the other light jobs, so a caller passing `runner` or `light-runner` still overrides it, and public repos keep `ubuntu-latest`.
