### PR TITLE
chore: add an org-wide FUNDING.yml default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: BryanFRD


### PR DESCRIPTION
Six repos carry their own `.github/FUNDING.yml` (FerrFlow, FerrFlow-Cloud, MCP, Benchmarks, Fixtures, the operator), all with the same one line. Every other repo — LFSX, the `-Cloud` platforms, Kit, UI, Status — has no sponsor button at all.

A `FUNDING.yml` in this repo is a default community health file: GitHub applies it to every repo in the org that does not define its own. LFSX already inherits `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and the PR template from here, so the mechanism is known to work on org repos.

The six local copies stay valid — a repo's own file wins — and can be deleted whenever, they are now redundant.