### PR TITLE
feat(ci): let reusable-docker-build check out a given ref

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -76,6 +76,16 @@ on:
         type: string
         required: false
         default: 'ubuntu-latest'
+      ref:
+        description: >-
+          Git ref to build. Empty (default) builds whatever the calling workflow
+          runs on, which is right for a release-triggered build. Pass the tag
+          when rebuilding an older version by hand: without it a manual re-run
+          builds the current branch and labels it with the version you asked
+          for, producing an image whose tag lies about its contents.
+        type: string
+        required: false
+        default: ''
     outputs:
       digest:
         description: 'Image digest (sha256:...)'
@@ -110,6 +120,8 @@ jobs:
     runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref }}
       - name: Lint Dockerfile (hadolint)
         run: |
           curl -fsSL https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 \
@@ -130,6 +142,8 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref }}
       # The self-hosted ARC runners have buildah, not a Docker daemon — so we
       # build/push with buildah (not docker/buildx). The cosign / Trivy / SBOM
       # jobs below pull the pushed image from the registry, so they need no


### PR DESCRIPTION
Consumers expose a `version` input on `workflow_dispatch` so a release whose image build failed can be given one later. It does not do what it looks like: this workflow checks out with no `ref`, so the build takes whatever the selected branch currently holds and the caller tags it with the version that was typed.

The result is an image whose tag makes a claim about its contents that is false, and nothing downstream can tell. That is worse than the missing image it was meant to repair.

Found on LFSX, where v0.17.1 had no image after a build failure. Dispatching a rebuild would have published `0.17.1` containing `main`; the run was cancelled instead. `binaries.yml` in that repo had the same defect on its own checkout, caught in review, and fixed there with one line — this is the same fix, one level down.

An optional `ref`, empty by default, so every current caller behaves exactly as before. Callers that want a truthful rebuild pass the tag.

Fixes the same latent problem for FerrGrowth, FerrTrack, FerrLens, FerrVault and Status, all of which carry a `version` dispatch input today.