### PR TITLE
fix(renovate): stop tracking this repo's references to itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>FerrLabs/.github"]
+  "extends": ["github>FerrLabs/.github"],
+  "packageRules": [
+    {
+      "description": "Ne pas suivre les references de ce depot vers lui-meme. Les workflows reutilisables d'ici s'appellent entre eux via FerrLabs/.github@<sha>, et `helpers:pinGitHubActionDigests` epingle ce sha. Chaque merge deplace main, ce qui perime le pin qui vient d'etre ecrit, ce qui produit la PR suivante : 18 commits de bot qui court apres sa propre queue (#249). La regle est locale a ce depot, les autres continuent de mettre a jour leur pin FerrLabs/.github normalement.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["FerrLabs/.github"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Closes #249

`FerrLabs/.github` pins its own reusable workflows by SHA, Renovate bumps that pin, automerge merges it, and the merge moves `main` so the pin it just wrote is stale again. Next run, next PR. Every 6 hours, plus the dispatch fired after a release.

The chain is in the log:

```
96957e8  chore(deps): update ferrlabs/.github digest to 7eb98f7 (#240)
7eb98f7  chore(deps): update ferrlabs/.github digest to 5aec567 (#239)
5aec567  chore(deps): update ferrlabs/.github digest to 7d6b75c (#238)
7d6b75c  chore(deps): update ferrlabs/.github digest to ef9da0f (#236)
```

`96957e8` bumps the pin to `7eb98f7`, and `7eb98f7` is itself a pin bump. 18 of these on `main`, the newest being #247.

**Fix**

One `packageRule` in this repo's own `renovate.json`, disabling the `FerrLabs/.github` dependency here. Repo-local: every other repo keeps updating its `FerrLabs/.github` pin, which is the case we actually want.

**Why not the other options**

- Pointing the ten self-references at `@main` instead of a SHA looks cleaner, but the org preset extends `helpers:pinGitHubActionDigests`, which re-pins them to a SHA on the next run. Same loop, one extra step.
- Local `./.github/workflows/…` paths do not work here: these files are invoked from other repositories, where a `./` reference resolves against the caller.

**Trade-off, and the reason I am not enabling automerge on this one**

The internal cross-references now freeze at the SHA they carry. A fix in `reusable-sonarqube-scan.yml` will not reach `reusable-ci-rust.yml` until someone bumps it deliberately. That is the point, but it turns a bot bump into a manual one, and it is your call whether that is the trade you want. Merge it if it is; otherwise the alternative is to keep the loop and treat those 18 commits as noise.
