### PR TITLE
fix(docker-build): degrade on a denied cache export instead of failing

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -57,7 +57,7 @@ on:
         required: false
         default: true
       cache:
-        description: 'Reuse a registry-side layer cache at `<image-name>-buildcache`. The ARC runners mount their container store on an emptyDir, so the local `--layers` cache dies with the pod and every build recompiles from scratch; keeping the cache in the registry is what makes it survive. A missing cache repo is a silent miss, so the first build just populates it. Set false for images whose layers are not worth caching.'
+        description: 'Reuse a registry-side layer cache at `<image-name>-buildcache`. The ARC runners mount their container store on an emptyDir, so the local `--layers` cache dies with the pod and every build recompiles from scratch; keeping the cache in the registry is what makes it survive. A missing cache repo is a silent miss, so the first build just populates it, and a denied cache export degrades to an uncached build with a warning rather than failing the job. Set false for images whose layers are not worth caching.'
         type: boolean
         required: false
         default: true
@@ -246,23 +246,46 @@ jobs:
           # A missing cache repo is a silent miss (verified with buildah
           # 1.33.7), so the first build simply populates it.
           cache_args=()
+          cache_to_args=()
           if [ "$CACHE" = "true" ] && [ "${IMAGE#ghcr.io/}" != "$IMAGE" ]; then
             CACHE_REPO="${IMAGE}-buildcache"
             cache_args+=(--cache-from "$CACHE_REPO" --cache-ttl "$CACHE_TTL")
             # Only publish the cache when we are publishing the image itself:
             # a build that is not pushed (smoke-test-only) must not overwrite
             # the cache other builds depend on.
-            [ "$PUSH" = "true" ] && cache_args+=(--cache-to "$CACHE_REPO")
+            [ "$PUSH" = "true" ] && cache_to_args+=(--cache-to "$CACHE_REPO")
             echo "Layer cache: $CACHE_REPO (ttl $CACHE_TTL, publish=$PUSH)"
           fi
 
-          buildah build \
-            --isolation=chroot --layers \
-            --platform "$PLATFORMS" \
-            "${cache_args[@]}" \
-            "${secret_args[@]}" "${build_arg_args[@]}" \
-            --manifest "$IMAGE:$TAG" \
-            -f "$CONTEXT/$DOCKERFILE" "$CONTEXT"
+          run_build() {
+            buildah build \
+              --isolation=chroot --layers \
+              --platform "$PLATFORMS" \
+              "$@" \
+              "${secret_args[@]}" "${build_arg_args[@]}" \
+              --manifest "$IMAGE:$TAG" \
+              -f "$CONTEXT/$DOCKERFILE" "$CONTEXT"
+          }
+
+          # A denied cache export must not fail a build whose image is fine.
+          # The first build of a new image creates its `-buildcache` package,
+          # and a package a workflow just created is not linked to the
+          # repository, so GITHUB_TOKEN has no write access and the export
+          # 403s once. Missing cache is already a silent miss; unwritable
+          # cache is the same class of event and costs a slower build, not a
+          # broken one. Every image added from now on hits this wall once.
+          #
+          # The retry reuses the layers the first attempt already committed to
+          # the local store, so it is a cache-hit pass rather than a rebuild.
+          build_log="$RUNNER_TEMP/buildah-build.log"
+          if run_build "${cache_args[@]}" "${cache_to_args[@]}" 2>&1 | tee "$build_log"; then
+            :
+          elif [ ${#cache_to_args[@]} -gt 0 ] && grep -qi 'pushing cache' "$build_log"; then
+            echo "::warning::layer cache export to ${CACHE_REPO} was denied; rebuilding without --cache-to. Link that GHCR package to this repository with write access to restore caching."
+            run_build "${cache_args[@]}"
+          else
+            exit 1
+          fi
 
           rm -f "$RUNNER_TEMP/packages-read" "$RUNNER_TEMP/cargo-registry-token" "$RUNNER_TEMP/gha-cache-url" "$RUNNER_TEMP/gha-runtime-token"
 


### PR DESCRIPTION
Closes #237

A denied cache export took down a build whose image was fine. `buildah build --cache-to` exits 125 when the registry refuses the cache push, and that exit code failed the job like any other build error.

**What changed**

The `buildah build` invocation moved into a `run_build()` helper, and `--cache-to` moved out of `cache_args` into its own `cache_to_args`. The build now runs like this:

```bash
if run_build "${cache_args[@]}" "${cache_to_args[@]}" 2>&1 | tee "$build_log"; then
  :
elif [ ${#cache_to_args[@]} -gt 0 ] && grep -qi 'pushing cache' "$build_log"; then
  echo "::warning::layer cache export to ${CACHE_REPO} was denied; rebuilding without --cache-to. …"
  run_build "${cache_args[@]}"
else
  exit 1
fi
```

The retry drops only `--cache-to`, so `--cache-from` still applies and the layers the first attempt already committed to the local store are reused. It is a cache-hit pass, not a rebuild.

**Why it degrades rather than ignores**

The workflow already treats a missing cache repo as a silent miss. An unwritable one is the same class of event, as the issue says: it costs a slower build, not a broken one. What it must not do is swallow a real failure, so the retry is gated on the buildah error string. Anything else still exits 1 on the first attempt, with no second build and no extra minutes burned.

**Verified**

The branch logic was exercised against a stub `buildah` covering the three cases:

```
STEP1: build ran with --cache-to
Error: failed pushing cache to …-buildcache: denied: permission_denied: HTTP status code 403
::warning::layer cache export to …-buildcache was denied; rebuilding without --cache-to.
STEP2: build ran without --cache-to
MODE=cache-denied -> exit 0

Dockerfile:7: RUN cargo build failed with exit code 101
MODE=broken-build -> exit 1

build ok
MODE=ok -> exit 0
```

A genuine build failure still fails, and it fails once. The workflow YAML parses and the extracted `run:` block passes `bash -n`.

**On the other half of the issue**

The GHCR package side needs nothing. Per the comment on #237, the replay succeeded without any permission change, so the package was created by that first push and the next write was accepted. What remains is this: the first build of every new image hits the wall once, and it should read as a warning rather than as a compilation failure.
