### PR TITLE
ci(pr-title): skip the title check on synchronize

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,16 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
+    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
+    # sur `synchronize` recalcule la même réponse. Renovate rebase en
+    # permanence, et une seule branche a représenté 24 des 100 derniers runs de
+    # ce workflow sur FerrGrowth-Cloud.
+    #
+    # On saute le job au lieu de retirer `synchronize` du déclencheur, et c'est
+    # délibéré : le workflow continue de produire un check run sur le nouveau
+    # SHA de tête, ce dont un status check requis a besoin, et un job sauté
+    # n'occupe aucun runner.
+    if: github.event.action != 'synchronize'
     runs-on: ferrlabs-k8s-light
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6

--- a/workflow-templates/pr-title.yml
+++ b/workflow-templates/pr-title.yml
@@ -10,7 +10,16 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ferrlabs-k8s
+    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
+    # sur `synchronize` recalcule la même réponse, et Renovate rebase en
+    # permanence.
+    #
+    # On saute le job au lieu de retirer `synchronize` du déclencheur, et c'est
+    # délibéré : le workflow continue de produire un check run sur le nouveau
+    # SHA de tête, ce dont un status check requis a besoin, et un job sauté
+    # n'occupe aucun runner.
+    if: github.event.action != 'synchronize'
+    runs-on: ferrlabs-k8s-light
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:


### PR DESCRIPTION
Closes #252

`synchronize` fires on every push to a PR branch, so every Renovate rebase reruns the title check and spins an ARC pod to recompute an answer that cannot have changed: a push does not touch the title.

On FerrGrowth-Cloud, `renovate/ferrlabs-actions` alone accounts for 24 of the last 100 runs of this workflow, and 57 of the last 60 runs across all branches are on `renovate/*`.

**The change**

```yaml
jobs:
  conventional:
    name: Conventional commits
    if: github.event.action != 'synchronize'
```

**Why skip the job rather than drop the trigger**

`Conventional commits` is a required status check in every repo carrying the `main: required CI checks` ruleset. Required checks are evaluated per head SHA, so if the workflow does not run after a rebase, the new SHA has no check and the PR is blocked until someone edits the title or reopens it. Removing `synchronize` from `types` would have done exactly that.

A job skipped through `if:` still produces a check run on the new head SHA, which satisfies the requirement, and a skipped job is never scheduled onto a runner. The trigger stays, the work goes.

**Also in here**

`workflow-templates/pr-title.yml` still said `runs-on: ferrlabs-k8s`, so anything scaffolded from the template landed on the 2-CPU tier to run a regex over a string. The repos moved to `ferrlabs-k8s-light` in #356; the template did not. Aligned, and it carries the same skip.

**Rollout**

This repo is the pilot on purpose. It is the only one where `Conventional commits` is not a required check, so the skip cannot block anything here, and the next `renovate/ferrlabs-actions` rebase will show whether the check reports as expected on the new SHA.

The other 19 repos each carry their own copy of this file and need the same one-line change. Worth doing as a sweep once we have seen a rebase land here, rather than shipping merge-gating behaviour to 19 private repos on a first attempt.
