### PR TITLE
chore: probe skipped-check behaviour

### DIFF
--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -44,3 +44,5 @@ Hosting the reusables in the **public** `.github` repo (rather than the private 
 | `security-scan` | `GITLEAKS_LICENSE` | Required for orgs with >25 contributors |
 | `release` | `FERRLABS_BOT_*` (FerrFlow OIDC) | Configured org-wide |
 | `docker-publish` | `GITHUB_TOKEN` | Auto-provided |
+
+<!-- probe -->

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -46,3 +46,4 @@ Hosting the reusables in the **public** `.github` repo (rather than the private 
 | `docker-publish` | `GITHUB_TOKEN` | Auto-provided |
 
 <!-- probe -->
+<!-- probe 2 -->


### PR DESCRIPTION
Throwaway PR to observe what the `Conventional commits` check reports on a `synchronize` now that the job is skipped (#252). Closed without merging.