### PR TITLE
ci: add a reusable PR title workflow

### DIFF
--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -1,0 +1,75 @@
+name: Reusable — PR title (Conventional Commits)
+
+# Le titre de la PR devient le message de commit sur `main` au squash-merge, et
+# FerrFlow en déduit le bump de version. Un titre mal formé produit donc
+# silencieusement une mauvaise version, ou aucune. D'où la validation.
+#
+# Les appelants déclarent :
+#
+#   on:
+#     pull_request_target: # zizmor: ignore[dangerous-triggers]
+#       types: [opened, edited, reopened, synchronize]
+#
+#   jobs:
+#     title:
+#       name: PR title
+#       uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@<sha>
+#
+# Le check produit s'appelle alors `PR title / Conventional commits` : un job
+# `uses:` compose toujours le nom de l'appelant et celui du job appelé. C'est ce
+# nom-là que les rulesets doivent exiger, pas `Conventional commits` seul.
+#
+# `pull_request_target` est délibéré et sûr : le job ne fait aucun `checkout`,
+# n'exécute donc rien qui vienne de la PR, et ne lit que le titre dans la charge
+# utile de l'événement avec `pull-requests: read`. C'est aussi ce qui empêche une
+# PR de fork d'affaiblir sa propre validation en modifiant le fichier, ce que
+# `pull_request` autoriserait.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
+        type: string
+        required: false
+        default: 'ferrlabs-k8s-light'
+
+permissions: {}
+
+jobs:
+  conventional:
+    name: Conventional commits
+    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
+    # sur `synchronize` recalcule la même réponse, et Renovate rebase en
+    # permanence. Une seule branche a représenté 24 des 100 derniers runs de ce
+    # workflow sur FerrGrowth-Cloud.
+    #
+    # On saute le job au lieu de retirer `synchronize` du déclencheur, et c'est
+    # délibéré : le workflow continue de produire un check run sur le nouveau
+    # SHA de tête, ce dont un status check requis a besoin, et un job sauté
+    # n'occupe aucun runner. Vérifié : le SHA porte alors
+    # `status=completed conclusion=skipped`.
+    if: github.event.action != 'synchronize'
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            chore
+            style
+            test
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^[A-Za-z].+$
+          subjectPatternError: |
+            Subject "{subject}" must start with an uppercase or lowercase letter and not be empty.


### PR DESCRIPTION
Refs #252

Adds `reusable-pr-title.yml`, so the title check stops being 20 copies of the same file.

We just swept a one-line change (`if: github.event.action != 'synchronize'`) across 20 repos, one PR each. `renovate-rebase.yml` shows the shape this should have had: a 10-line caller per repo, all the logic here, one place to fix.

**The catch, and why this is not a drop-in**

A `uses:` job does not report a check under the caller's job name. GitHub composes `<caller job name> / <reusable job name>`, which the org's own rulesets already show:

| Workflow | Context produced |
|---|---|
| job `Check` (matrix) calling `reusable-ci-node` | `Check (app) / Quality (knip, madge, audit)` |
| job `Check API` calling `reusable-ci-rust` | `Check API / Test` |
| job `Check i18n (site)`, local | `Check i18n (site)` |

So a repo that migrates stops producing `Conventional commits` and starts producing `PR title / Conventional commits`. That context is a **required status check in 17 of the 20 repos**, so migrating a repo without updating its ruleset in the same window blocks every PR there.

This PR only adds the reusable. Nothing calls it yet.

**Rollout**

`Fixtures` first: it is one of the three repos (with `Docker-Runners` and `FerrGames-Discord`) where the title check is not required, so the migration cannot block anything and the composed check name can be read off a real PR before touching any ruleset.

**Details**

- `runner` input, defaulting to `ferrlabs-k8s-light`. Public repos pass `ubuntu-latest`; the `ferrlabs-k8s` group sets `allows_public_repositories=false`. Same input `reusable-renovate-dispatch.yml` already carries.
- `permissions: {}` at workflow level, `pull-requests: read` on the job.
- The steps are byte-identical to the current per-repo file, including the action pin.
- The header documents the caller shape, the composed check name, and why `pull_request_target` is deliberate here.
