### PR TITLE
fix(pr-title): declare the permission at workflow level

### DIFF
--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -10,10 +10,20 @@ name: Reusable — PR title (Conventional Commits)
 #     pull_request_target: # zizmor: ignore[dangerous-triggers]
 #       types: [opened, edited, reopened, synchronize]
 #
+#   permissions:
+#     pull-requests: read
+#
 #   jobs:
 #     title:
 #       name: PR title
 #       uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@<sha>
+#
+# Le bloc `permissions` de l'appelant n'est pas facultatif : un workflow appelé
+# ne peut que restreindre ce que l'appelant lui donne, jamais l'élargir. Sans
+# lui, le run finit en `startup_failure` avec « is requesting 'pull-requests:
+# read', but is only allowed 'pull-requests: none' », et un startup_failure ne
+# produit AUCUN check run sur le SHA de tête. Sur un dépôt où ce check est
+# requis, c'est un blocage silencieux de toutes les PR.
 #
 # Le check produit s'appelle alors `PR title / Conventional commits` : un job
 # `uses:` compose toujours le nom de l'appelant et celui du job appelé. C'est ce

--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -34,7 +34,8 @@ on:
         required: false
         default: 'ferrlabs-k8s-light'
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   conventional:
@@ -51,8 +52,6 @@ jobs:
     # `status=completed conclusion=skipped`.
     if: github.event.action != 'synchronize'
     runs-on: ${{ inputs.runner }}
-    permissions:
-      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:


### PR DESCRIPTION
Refs #252

Follow-up to #255. The reusable declared `permissions: {}` at workflow level and `pull-requests: read` on the job, which GitHub rejects for a called workflow. Measured on a probe in `FerrLabs/Fixtures`:

```
Error calling workflow 'FerrLabs/.github/.github/workflows/reusable-pr-title.yml@…'.
The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

A called workflow can only narrow what the caller granted, never exceed it. Moving the permission to the workflow level here is half the fix; the other half is on each caller, which must declare

```yaml
permissions:
  pull-requests: read
```

That is not boilerplate. Without it the run ends in `startup_failure`, and a startup failure produces **no check run at all** on the head SHA. On the 17 repos where this check is required, that is a silent block on every PR. Documented in the reusable's header so nobody copies a caller without it.

Verified after the fix, on a `synchronize`:

```
PR title / Conventional commits | completed skipped
```

Which also confirms the composed context name the rulesets will need to require.
