### PR TITLE
fix(ci): repair the docker build script and check every run block parses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,64 @@
+name: Lint
+
+# The reusables in this repository are shell scripts wearing YAML. A syntax
+# error in one of them is not caught by anything here — it surfaces in whichever
+# product repository next bumps its pin, as a job that dies before its first
+# line runs. That is how a stray `if` shipped org-wide and every image build
+# using it failed identically.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  scripts:
+    name: Workflow scripts parse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - run: pip install --quiet pyyaml
+
+      - name: bash -n every run block
+        run: |
+          python3 - <<'PY'
+          import pathlib, re, subprocess, sys, tempfile, yaml
+
+          def scripts(workflow):
+              for name, job in (workflow.get("jobs") or {}).items():
+                  default = ((job.get("defaults") or {}).get("run") or {}).get("shell")
+                  for index, step in enumerate(job.get("steps") or []):
+                      run = step.get("run")
+                      shell = step.get("shell", default)
+                      if run and shell in (None, "bash", "sh", "bash -e {0}"):
+                          yield name, index, step.get("name", f"step {index}"), run
+
+          failed = 0
+          for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+              loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+              for job, index, label, run in scripts(loaded):
+                  # An expression can expand to anything, including nothing, so
+                  # substitute a placeholder rather than guess: this checks the
+                  # shape of the script, not the values it will be given.
+                  source = re.sub(r"\$\{\{.*?\}\}", "EXPRESSION", run, flags=re.S)
+                  with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False, encoding="utf-8") as handle:
+                      handle.write(source)
+                      probe = handle.name
+                  check = subprocess.run(["bash", "-n", probe], capture_output=True, text=True)
+                  if check.returncode:
+                      failed += 1
+                      print(f"::error file={path}::{job} / {label}: {check.stderr.strip()}")
+
+          print("no unparseable run blocks" if not failed else f"{failed} unparseable run block(s)")
+          sys.exit(1 if failed else 0)
+          PY

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -214,8 +214,8 @@ jobs:
           # neither: a key without its secret would have the Dockerfile wire up
           # sccache against credentials that cannot authenticate, turning a
           # cache miss into a build failure.
-          if [ "${SCCACHE_GHA:-false}" = "true" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
           if [ "${SCCACHE_GHA:-false}" = "true" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ] && [ -n "${ACTIONS_CACHE_URL:-${ACTIONS_RESULTS_URL:-}}" ]; then
+            printf '%s' "${ACTIONS_CACHE_URL:-${ACTIONS_RESULTS_URL}}" >"$RUNNER_TEMP/gha-cache-url"
             printf '%s' "$ACTIONS_RUNTIME_TOKEN" >"$RUNNER_TEMP/gha-runtime-token"
             secret_args+=(--secret "id=gha-cache-url,src=$RUNNER_TEMP/gha-cache-url")
             secret_args+=(--secret "id=gha-runtime-token,src=$RUNNER_TEMP/gha-runtime-token")


### PR DESCRIPTION
The Actions-cache work in #248 left two defects in `reusable-docker-build.yml`, both inside the same six lines:

```bash
if [ "${SCCACHE_GHA:-false}" = "true" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
if [ "${SCCACHE_GHA:-false}" = "true" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ] && [ -n "${ACTIONS_CACHE_URL:-...}" ]; then
```

Two `if`s, one `fi`. **The step's script does not parse at all**, so every caller pinned at or after 30a2f74 dies before its first line whatever it passes in: `line 135: syntax error: unexpected end of file from 'if' command on line 16`. And `gha-cache-url` was handed to buildah as a secret whose source file nothing ever wrote, so the block would have failed a second time once it parsed.

The repositories still publishing images are the ones whose pin has not moved yet. This is waiting for each of them at their next Renovate bump.

## The guard

A reusable here is a shell script wearing YAML, and nothing in this repository ever parses it. The breakage surfaces in someone else's repository, days later, as a job that dies before it starts — which is exactly what happened: five LFSX releases shipped with no image behind them, and the homelab went down for seventeen minutes pulling a tag that was never built.

`lint.yml` extracts every `run:` block from every workflow and runs `bash -n` over it. Expressions are replaced by a placeholder first, since `${{ }}` can expand to anything including nothing — this checks the shape of the script, not the values it will be handed.

Verified in both directions: 88 blocks parse on this branch, and the same check run against `main` reports the failure above.

It will not catch a bad flag or a wrong path. It catches a script that cannot run at all, which is the class that has actually cost releases.