### PR TITLE
chore(deps): bump the ferrflow action to v7.0.2

### DIFF
--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -71,7 +71,7 @@ jobs:
       # repo has a Cargo.toml.
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: FerrLabs/FerrFlow@d4f48a7986df6be38bc560ec7da4014339132ba4 # v7.0.0
+      - uses: FerrLabs/FerrFlow@e67df5db9495d53696fa4c6b85d48337eeeaf31d # v7.0.2
         env:
           # Lets cargo-based postBump hooks read the private Kellnr index.
           # Empty (and unused) for repos that don't consume Kellnr.
@@ -103,7 +103,7 @@ jobs:
       # private Kellnr index for dependency metadata).
       - if: ${{ hashFiles('**/Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: FerrLabs/FerrFlow@d4f48a7986df6be38bc560ec7da4014339132ba4 # v7.0.0
+      - uses: FerrLabs/FerrFlow@e67df5db9495d53696fa4c6b85d48337eeeaf31d # v7.0.2
         env:
           CARGO_REGISTRIES_KELLNR_TOKEN: ${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}
         with:

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -14,7 +14,7 @@ GitHub-discovered workflow templates. They appear under **Actions → New workfl
 | [`scorecard`](scorecard.yml) | OpenSSF Scorecard supply-chain risk score | All public repos and key private repos. |
 | [`security-scan`](security-scan.yml) | Reusable: gitleaks (secrets) + osv-scanner (CVE) + trufflehog (deep history) | Every repo — call the shared workflow from `FerrLabs/.github`. |
 | [`pr-title`](pr-title.yml) | Conventional Commits validation on PR titles | Every repo (mandatory because we squash-merge). |
-| [`release`](release.yml) | Auto-release on push to main with `FerrLabs/FerrFlow@v5` | Repos that ship semver releases. |
+| [`release`](release.yml) | Auto-release on push to main with `FerrLabs/FerrFlow@v7` | Repos that ship semver releases. |
 | [`docker-publish`](docker-publish.yml) | Reusable: hadolint + multi-arch build + Trivy + cosign keyless + SBOM | Repos that publish a container image. |
 
 ## Reusable workflows

--- a/workflow-templates/release.properties.json
+++ b/workflow-templates/release.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "FerrLabs — Release with FerrFlow",
-  "description": "Automatic semver release on push to main using FerrLabs/FerrFlow@v5 (conventional commits, version bump, tag, GitHub release, changelog).",
+  "description": "Automatic semver release on push to main using FerrLabs/FerrFlow@v7 (conventional commits, version bump, tag, GitHub release, changelog).",
   "iconName": "ferrlabs",
   "categories": ["Deployment"],
   "filePatterns": [".*"]


### PR DESCRIPTION
Picks up the `updateLockfiles` fix (FerrLabs/FerrFlow#844, shipped in v7.0.1).

Releases with `updateLockfiles: true` were bumping the manifest and leaving `Cargo.lock` at the previous version. The failure was logged as a warning, so the release finished green and the drift only surfaced later as a dirty tree. Two causes: `cargo update -p` was given the FerrFlow package name instead of the crate name, and `--offline` cannot resolve on the cold registry cache a release job always has. Three repos have needed a manual lock sync because of it (FerrGames-Cloud#1001, FerrGames-Discord#90, FerrVault-Cloud#714), and it keeps recurring until this pin moves.

Diffing v7.0.0..v7.0.2, the only source change is that fix:

```
src/formats/lockfiles.rs   +106-16
src/monorepo/run/mod.rs      +1-1
src/monorepo/tests.rs        +1-1
```

Everything else in the range is Renovate digest bumps, docs and CI inside the FerrFlow repo. v7.0.2 adds only a CI permissions fix on top of v7.0.1.

Also refreshes the two `workflow-templates` descriptions that still advertised `FerrFlow@v5`; the template itself has called the reusable workflow for a while, so the prose was simply stale.