### PR TITLE
fix(renovate): authenticate docker datasource lookups on ghcr.io and lscr.io

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -270,6 +270,16 @@ jobs:
           # (CrateDatasource.id) — `cargo` is the manager and matches nothing,
           # so the Kellnr rule silently contributed no token and the sparse
           # index answered 401, surfacing as the same `no-result` as above.
+          #
+          # The `docker` hostRules cover image lookups (the `tags/list` API, not
+          # a pull). Without them Renovate queries anonymously and shares the
+          # per-IP quota of a GitHub-hosted runner with everyone else on it, so
+          # lookups intermittently answer 429 TOOMANYREQUESTS and degrade to
+          # `no-result`, silently skipping the update. lscr.io is a GHCR front
+          # for linuxserver images and authenticates the same way. This is
+          # unrelated to the cluster's pull-through caches: those are wired into
+          # containerd via /etc/containerd/certs.d and only serve node-side
+          # image pulls, never metadata lookups from a hosted runner.
           RENOVATE_HOST_RULES: |
             [
               {
@@ -291,5 +301,15 @@ jobs:
                 "matchHost": "crates.ferrlabs.com",
                 "hostType": "crate",
                 "token": "${{ secrets.CARGO_REGISTRIES_KELLNR_TOKEN }}"
+              },
+              {
+                "matchHost": "ghcr.io",
+                "hostType": "docker",
+                "token": "${{ secrets.GITHUB_TOKEN }}"
+              },
+              {
+                "matchHost": "lscr.io",
+                "hostType": "docker",
+                "token": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]


### PR DESCRIPTION
## Summary

Renovate image lookups (the registry `tags/list` API, not image pulls) were sent anonymously, so they shared the per-IP quota of the GitHub-hosted runner with every other tenant on it. Result: intermittent `429 TOOMANYREQUESTS`, the lookup degrading to `no-result`, and the update being silently skipped.

Observed in run 32032215901, shard `rest`, on `FerrLabs/Homelab`:

```
"apiCheckUrl": "https://lscr.io/v2/linuxserver/speedtest-tracker/tags/list?n=10000",
"statusCode": 429, "code": "TOOMANYREQUESTS", "authorization": false
-> Failed to look up docker package lscr.io/linuxserver/speedtest-tracker: no-result
```

`RENOVATE_HOST_RULES` had rules for `npm`, `github-tags`, `git-refs` and `crate`, but none for the `docker` datasource.

This is unrelated to the cluster's pull-through caches (`k8s/registry/`): those are wired into containerd through `/etc/containerd/certs.d` by the `registry-mirror-config` DaemonSet, so they only serve node-side image pulls, never metadata lookups from a hosted runner.

## Changes

- Add two `docker` hostRules to `RENOVATE_HOST_RULES`, for `ghcr.io` and `lscr.io` (a GHCR front for linuxserver images), both using `GITHUB_TOKEN`.
- Document why they are there and why the in-cluster caches do not cover this.

The job already declares `permissions: packages: read`, which is what `GITHUB_TOKEN` needs here.

## Testing

Not run against the live schedule. Verified locally that the workflow still parses as YAML and that `RENOVATE_HOST_RULES` still parses as JSON with the six expected (matchHost, hostType) pairs.

## Follow-up (not in this PR)

Docker Hub lookups are still anonymous: there is no Docker Hub secret at the org level. Credentials exist in OpenBao under `secret/registry/dockerhub` (used by the pull-through proxy) and would need to be published as org secrets before an `index.docker.io` rule can be added.