### PR TITLE
ci(rust): pin dependency resolution with --locked on every cargo run

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -225,12 +225,12 @@ jobs:
         if: inputs.check-clippy
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo clippy ${{ inputs.cargo-flags }} -- ${{ inputs.clippy-args }}
+        run: cargo clippy --locked ${{ inputs.cargo-flags }} -- ${{ inputs.clippy-args }}
       - name: Tests
         if: inputs.run-tests
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo test ${{ inputs.cargo-flags }} ${{ inputs.test-args }}
+        run: cargo test --locked ${{ inputs.cargo-flags }} ${{ inputs.test-args }}
 
   # DB-backed integration tests. Postgres is provided out-of-band by the shared
   # `postgres-ci` pod (ns github-runner) instead of being apt-installed inside
@@ -314,7 +314,7 @@ jobs:
       - name: Pre-compile integration test binaries
         env:
           INTEGRATION_ARGS: ${{ inputs.integration-args }}
-        run: cargo test --no-run ${INTEGRATION_ARGS%% -- *}
+        run: cargo test --locked --no-run ${INTEGRATION_ARGS%% -- *}
       - name: Create per-run database
         env:
           DB_ENV_NAME: ${{ inputs.integration-db-env }}
@@ -343,7 +343,7 @@ jobs:
           set -uo pipefail
           for attempt in 1 2 3; do
             echo "::group::Integration attempt ${attempt}/3"
-            if cargo test $INTEGRATION_ARGS; then echo "::endgroup::"; exit 0; fi
+            if cargo test --locked $INTEGRATION_ARGS; then echo "::endgroup::"; exit 0; fi
             echo "::endgroup::"
             sleep 5
           done
@@ -513,13 +513,13 @@ jobs:
         if: inputs.coverage-tool == 'llvm-cov'
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo llvm-cov ${{ inputs.coverage-flags || inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --locked ${{ inputs.coverage-flags || inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
       - name: Generate coverage (tarpaulin)
         if: inputs.coverage-tool == 'tarpaulin'
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
         run: |
-          cargo install cargo-tarpaulin
+          cargo install --locked cargo-tarpaulin
           cargo tarpaulin --out xml --skip-clean
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/snippets/deny.toml
+++ b/snippets/deny.toml
@@ -27,6 +27,14 @@ confidence-threshold = 0.93
 multiple-versions = "warn"
 wildcards = "deny"
 highlight = "all"
+deny = [
+  { crate = "proc-macro1", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+  { crate = "proc-macro-en", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+  { crate = "aovine", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+  { crate = "arone", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+  { crate = "aronenao", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+  { crate = "tinymember", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
Closes #271

Fallout from the 2026-08-20 `arrayref` supply-chain attack. We were not hit (every lockfile in the org pins `arrayref = 0.3.9`, no `internment`, no `append-only-vec`, none of the six attacker crates), but CI had no mechanism that would have stopped it either.

## Changes

`reusable-ci-rust.yml`, `--locked` on every cargo call that resolves dependencies:

| Step | Before | After |
|---|---|---|
| Clippy | `cargo clippy <flags>` | `cargo clippy --locked <flags>` |
| Tests | `cargo test <flags>` | `cargo test --locked <flags>` |
| Integration pre-compile | `cargo test --no-run` | `cargo test --locked --no-run` |
| Integration tests | `cargo test $INTEGRATION_ARGS` | `cargo test --locked $INTEGRATION_ARGS` |
| Coverage | `cargo llvm-cov <flags>` | `cargo llvm-cov --locked <flags>` |
| Coverage (tarpaulin) | `cargo install cargo-tarpaulin` | `cargo install --locked cargo-tarpaulin` |

`cargo fmt` is untouched (it does not resolve). `cargo deny`, `cargo audit` and `cargo machete` are untouched too: they do not accept `--locked`, and `cargo-flags` is shared with them, which is why the flag goes on the individual commands rather than into the `cargo-flags` default.

The tarpaulin line is the one that was genuinely unlocked: it resolved tarpaulin's whole tree fresh on every coverage run.

`snippets/deny.toml`, the six attacker crates in `[bans].deny` with a `reason` each.

## Scope, honestly

The deny entries do almost nothing today. The crates are deleted from crates.io, and every product sets `enable-deny: false` because none of them ships a `deny.toml`. It only matters for repos that adopt the snippet later. The `--locked` half is the part that carries weight.

## Expected fallout

Products pin this workflow by SHA, so nothing changes for them until each repo bumps its pin. The first bump may go red where a lockfile has drifted from its `Cargo.toml`. That is the check working, and the fix is regenerating and committing the lock.