### PR TITLE
ci(rust): pass cargo flags through env instead of expanding them into run

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -225,12 +225,16 @@ jobs:
         if: inputs.check-clippy
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo clippy --locked ${{ inputs.cargo-flags }} -- ${{ inputs.clippy-args }}
+          CARGO_FLAGS: ${{ inputs.cargo-flags }}
+          CLIPPY_ARGS: ${{ inputs.clippy-args }}
+        run: cargo clippy --locked $CARGO_FLAGS -- $CLIPPY_ARGS
       - name: Tests
         if: inputs.run-tests
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo test --locked ${{ inputs.cargo-flags }} ${{ inputs.test-args }}
+          CARGO_FLAGS: ${{ inputs.cargo-flags }}
+          TEST_ARGS: ${{ inputs.test-args }}
+        run: cargo test --locked $CARGO_FLAGS $TEST_ARGS
 
   # DB-backed integration tests. Postgres is provided out-of-band by the shared
   # `postgres-ci` pod (ns github-runner) instead of being apt-installed inside
@@ -424,7 +428,9 @@ jobs:
           fi
       - name: cargo deny
         if: inputs.enable-deny
-        run: cargo deny ${{ inputs.cargo-flags }} check
+        env:
+          CARGO_FLAGS: ${{ inputs.cargo-flags }}
+        run: cargo deny $CARGO_FLAGS check
       - name: cargo machete (unused deps)
         if: inputs.enable-machete
         run: |
@@ -513,7 +519,8 @@ jobs:
         if: inputs.coverage-tool == 'llvm-cov'
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-        run: cargo llvm-cov --locked ${{ inputs.coverage-flags || inputs.cargo-flags }} --workspace --lcov --output-path lcov.info
+          COVERAGE_FLAGS: ${{ inputs.coverage-flags || inputs.cargo-flags }}
+        run: cargo llvm-cov --locked $COVERAGE_FLAGS --workspace --lcov --output-path lcov.info
       - name: Generate coverage (tarpaulin)
         if: inputs.coverage-tool == 'tarpaulin'
         env:


### PR DESCRIPTION
Closes #273

Follow-up to #272. Four steps in `reusable-ci-rust.yml` expanded `workflow_call` inputs directly into their `run:` block, so the Actions templating engine substituted the value before the shell ever saw the line. zizmor flags this as `template-injection`.

| Step | Before | After |
|---|---|---|
| Clippy | `cargo clippy --locked ${{ inputs.cargo-flags }} -- ${{ inputs.clippy-args }}` | `$CARGO_FLAGS` / `$CLIPPY_ARGS` via `env:` |
| Tests | `cargo test --locked ${{ inputs.cargo-flags }} ${{ inputs.test-args }}` | `$CARGO_FLAGS` / `$TEST_ARGS` via `env:` |
| Coverage | `cargo llvm-cov --locked ${{ inputs.coverage-flags \|\| inputs.cargo-flags }}` | `$COVERAGE_FLAGS` via `env:` |
| cargo deny | `cargo deny ${{ inputs.cargo-flags }} check` | `$CARGO_FLAGS` via `env:` |

This is the pattern the file already uses in the integration job (`INTEGRATION_ARGS`), so nothing new is introduced. The variables stay unquoted on purpose: these inputs carry several flags and need word splitting, same as `$INTEGRATION_ARGS` above them.

Behaviour is unchanged for every current caller.

## Why this is a separate PR

The fix was written during #272 but that PR auto-merged on its required checks before the commit landed, and the branch was deleted underneath it. zizmor is not a required check, so a failing run did not hold the merge. Worth knowing: a red zizmor on a `.github` PR will not stop it from shipping.