### PR TITLE
fix(docker): laisse l'appelant choisir le runner des jobs annexes

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -76,6 +76,20 @@ on:
         type: string
         required: false
         default: 'ubuntu-latest'
+      helper-runner:
+        description: >-
+          Runner label for the four supporting jobs (hadolint, Trivy, cosign,
+          SBOM). Leave empty to keep the historical behaviour: the self-hosted
+          `ferrlabs-k8s` pool on a private repository, `ubuntu-latest` on a
+          public one. That default reads a repository''s VISIBILITY as a proxy
+          for WHICH ORGANISATION owns it, which holds only while every private
+          consumer is a FerrLabs repository. A private repository in another
+          organisation targets a runner label that does not exist there, and its
+          jobs queue forever with no error. Such a consumer passes
+          `ubuntu-latest` here.
+        type: string
+        required: false
+        default: ''
       sccache-gha:
         description: >-
           Cache compiled artifacts in the GitHub Actions cache for the duration
@@ -128,7 +142,7 @@ jobs:
     # hadolint via its static binary (not the hadolint-action Docker container)
     # so it runs on the self-hosted pool for private repos — the ARC runners
     # have buildah but no Docker daemon. Public repos fall back to ubuntu-latest.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -341,7 +355,7 @@ jobs:
     # medium, not inputs.runner (-large): Trivy just pulls the pushed image
     # from the registry and scans it — no buildah/compile, so it doesn't need
     # the scarce 2-slot large tier. Frees a large slot per docker-build run.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       # Trivy reads ~/.docker/config.json to pull the image; without this a
       # private GHCR image fails with a 401/manifest-unknown.
@@ -394,7 +408,7 @@ jobs:
     # self-hosted pool for private repos. Public repos fall back to ubuntu-latest.
     # Keyless signing uses the Actions OIDC token, which is available on
     # self-hosted runners too (needs id-token: write, already granted).
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       - name: Install cosign
         run: |
@@ -433,7 +447,7 @@ jobs:
     if: inputs.push
     # medium, not inputs.runner (-large): Syft pulls the pushed image and
     # generates the SBOM — no buildah/compile, so no need for the large tier.
-    runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     steps:
       # Syft pulls the image via the Docker keychain (~/.docker/config.json);
       # a private GHCR image needs this login or the scan fails to fetch it.


### PR DESCRIPTION
Quatre des cinq jobs de `reusable-docker-build` déduisent leur runner de la **visibilité** du dépôt :

```yaml
runs-on: ${{ github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest' }}
```

C'est un raccourci qui lit « privé » comme un synonyme de « appartient à FerrLabs ». Il tient tant que tout consommateur privé est un dépôt FerrLabs, et cesse de tenir dès qu'une autre organisation utilise ce workflow.

## Comment ça se manifeste

`IdleWarden/idlewarden-cloud` est privé et n'a aucun runner auto-hébergé. Ses jobs `hadolint`, `trivy`, `cosign` et `sbom` visent donc `ferrlabs-k8s`, un label qui n'existe pas chez lui, et **attendent indéfiniment sans le moindre message**. Le job `meta` réussit, le job de construction démarre, et le run reste bloqué.

Seul `build` échappait au problème : lui seul respecte l'entrée `runner`.

## Le correctif

Une entrée `helper-runner`, vide par défaut :

```yaml
runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
```

Vide, l'expression se réduit exactement à l'ancienne. **Aucun appelant existant ne change de comportement**, ce qui compte pour un fichier que tous les dépôts utilisent : une régression ici les casserait tous d'un coup.

Un consommateur privé hors FerrLabs passe `ubuntu-latest`.

## Pourquoi une entrée plutôt qu'un test sur le propriétaire

Tester `github.repository_owner == 'FerrLabs'` corrigerait ce cas précis et reproduirait la même erreur de forme : le workflow continuerait de deviner ce que l'appelant sait déjà. Une entrée explicite laisse la décision là où l'information est, et n'a pas besoin d'être modifiée à chaque organisation ajoutée.

## Vérifié

Les quatre jobs sont recâblés, `build` est inchangé, et le YAML se relit correctement. L'entrée est documentée avec le piège qu'elle évite, pour que le prochain à passer par là n'ait pas à le redécouvrir depuis un run bloqué sans logs.
