### PR TITLE
chore(renovate): take non-.github FerrLabs actions weekly instead of on every release

### DIFF
--- a/default.json
+++ b/default.json
@@ -149,9 +149,9 @@
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Actions et workflows réutilisables maison — pas de délai, pas d'attente du lundi. La règle précédente fait patienter 3 jours parce que les auteurs tiers re-taguent après publication ; sur nos propres dépôts ce risque n'existe pas, on contrôle le contenu et le SHA. Sans cette exception, un changement dans FerrLabs/.github met jusqu'à quatre jours à atteindre les dépôts consommateurs (schedule lundi + 3 jours d'âge), ce qui bloque toute bascule coordonnée. `FerrLabs/.github` est nommé explicitement : un glob minimatch n'attrape pas un segment commençant par un point.",
+      "description": "FerrLabs/.github reusable workflows: no delay, no waiting for Monday. The previous rule waits 3 days because third-party authors re-tag after publishing; that risk does not exist on our own repositories, where we control both the content and the SHA. Without this exception a change in FerrLabs/.github takes up to four days to reach consumers (Monday schedule plus 3 days of age), which blocks any coordinated switchover. `FerrLabs/.github` is named explicitly because a minimatch glob does not match a segment starting with a dot.",
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["FerrLabs/.github", "FerrLabs/**"],
+      "matchPackageNames": ["FerrLabs/.github"],
       "schedule": ["at any time"],
       "minimumReleaseAge": "0",
       "internalChecksFilter": "none",
@@ -159,6 +159,18 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "FerrLabs actions"
+    },
+    {
+      "description": "Every other FerrLabs action, the ferrflow action above all: grouped and taken weekly. These do not need to arrive within the hour, and taking each release the moment it landed was the main source of digest churn. Every commit here changes this repository's digest, 26 repositories pin that digest, so one release fanned out into as many pull requests. In the week before this rule, 12 of the 16 commits here were ferrflow action bumps. Consumers of FerrLabs/.github itself keep the immediate cadence above, which is what that exception exists for.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["FerrLabs/**", "!FerrLabs/.github"],
+      "schedule": ["before 6am on monday"],
+      "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrLabs actions (weekly)"
     },
     {
       "description": "Dockerfile base images — wait 3 days, grouped + auto-merge weekly",


### PR DESCRIPTION
Closes #286.

330 pull requests merged in one week across 26 repositories, all bumping the same dependency. This cuts the source rather than the symptom.

## A correction to the issue

The issue title says "group", but grouping was never the problem: rule 6 already carries `groupName: FerrLabs actions`. Grouping merges several dependencies into one pull request per run, and each consumer has exactly one `FerrLabs/.github` dependency, so it had nothing to merge. The volume comes from **frequency**, not from a missing group, so scheduling is the only lever that moves it.

## What was actually happening

Rule 6 matched `["FerrLabs/.github", "FerrLabs/**"]` on `schedule: ["at any time"]`. Its own description explains why that exception exists, and it is entirely about one dependency:

> Without this exception a change in FerrLabs/.github takes up to four days to reach consumers, which blocks any coordinated switchover.

But `FerrLabs/**` also swept in `FerrLabs/FerrFlow`, the ferrflow action, which the rationale never mentions and which has no reason to arrive within the hour. That was the loop's fuel:

```
FerrFlow releases          →  .github bumps the ferrflow action immediately
  →  .github's digest changes
    →  26 repositories bump the digest
```

In the week I measured, **12 of 16 commits to this repository were ferrflow action bumps**. Each one changed the digest and fanned out to 26 consumers.

## The change

Rule 6 now matches `FerrLabs/.github` alone and keeps its immediate cadence, so a shared workflow fix still reaches consumers within the hour, which is the property that exception was written to protect.

A new rule takes every other FerrLabs action weekly, grouped and auto-merged, matching `["FerrLabs/**", "!FerrLabs/.github"]`.

Fewer commits here means fewer digests, which means fewer downstream pull requests, without asking any of the 26 consumers to change anything.

## Not a loop, but close to one

Worth recording while it is fresh. The cycle terminates only because the digest bump lands as `chore(deps)`, and `chore` produces no version bump. Nothing in the preset states that requirement: it extends `:semanticCommits` and no rule overrides `semanticCommitType`, so it rests entirely on Renovate's default. A rule that ever set `fix` for actions would make this genuinely infinite, since the release would bump this repository again. Left as an observation in #286 rather than a change here.

## Verified

`renovate-config-validator --strict` run locally over the same three files as the self-check job:

```
INFO: Config validated successfully against 3 file(s)
```

The rule 6 description was in French and is rewritten in English, since the rule's meaning changed and the description had to be accurate either way.

## What this does not do

The remaining churn is whatever else commits here. If it is still noisy after a week, the next lever is on the consumer side: a `schedule` on `FerrLabs/.github` itself, which trades propagation speed for quiet and should be a deliberate decision rather than a side effect.
