### PR TITLE
ci: run the workflow parse check on every pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,6 @@ name: Lint
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
`Workflow scripts parse` is the check that catches a syntax error before it ships org-wide, but it cannot be made a required context while it is path-filtered: on a pull request that touches no workflow it never reports, and a required context that never reports stays pending forever.

Dropping the filter from the `pull_request` trigger makes it report on every pull request. The job is a checkout, a `pip install pyyaml` and a parse, so the cost on unrelated pull requests is small. The push trigger keeps its filter.

The ruleset requiring this check goes in once this merges.

Closes #288
