### PR TITLE
chore(funding): sponsor the FerrLabs org instead of a personal account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: BryanFRD
+github: FerrLabs


### PR DESCRIPTION
Closes #290

```diff
-github: BryanFRD
+github: FerrLabs
```

This file is the org-wide default, so it drives the Sponsor button on every public repo that does not ship its own `FUNDING.yml`. It was pointing at a personal account.

The org has a public Sponsors listing (`sponsors-FerrLabs`, confirmed via `hasSponsorsListing`), so the button resolves to `github.com/sponsors/FerrLabs`.

One detail worth recording: the `github:` key takes an **account name**, not a URL. Writing the full `https://github.com/FerrLabs` there would be rejected by GitHub's parser. A raw URL only belongs under `custom:`, which would render a plain link rather than the native sponsor flow, so the account-name form is the right one here.