### PR TITLE
ci(pr-title): run the title check on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,7 +25,7 @@ jobs:
     # SHA de tête, ce dont un status check requis a besoin, et un job sauté
     # n'occupe aucun runner.
     if: github.event.action != 'synchronize'
-    runs-on: ferrlabs-k8s-light
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:


### PR DESCRIPTION
Closes #292

```diff
-    runs-on: ferrlabs-k8s-light
+    runs-on: ubuntu-latest
```

This repo is public and the `ferrlabs-k8s` group sets `allows_public_repositories=false`, so nothing could ever pick the job up. It has been sitting at `status: queued` on every PR since #227 landed on 2026-08-14.

Because `Conventional commits` is not a required check, PRs merged anyway with it queued (#272 and #274 both did). So this is not a blocked-merge bug, it is a **silently dead gate**: no PR title on this repo has actually been validated for two weeks.

Every other public repo in the org already passes `ubuntu-latest` to `reusable-pr-title.yml` — FerrFlow, Changelog, FerrVault, MCP, Fixtures, LFSX, Benchmarks. This repo owns the workflow and was the only one that missed its own advice.

Hosted runners are free and unlimited on public repos, so this also stops queueing work against the self-hosted pool for no reason.

## This PR will still show the stuck job

`pull_request_target` evaluates the workflow from the base branch, which is deliberate here (it stops a fork PR from weakening its own validation). The consequence is that the fix only applies to PRs opened after it reaches `main`, so `Conventional commits` will be queued on this PR too. That is expected, not a reason to hold it.