### PR TITLE
ci(pr-title): auto-select the runner by repo visibility

### DIFF
--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -39,10 +39,10 @@ on:
   workflow_call:
     inputs:
       runner:
-        description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use ferrlabs-k8s-light, public repos use ubuntu-latest. The ferrlabs-k8s group sets allows_public_repositories=false, so a public repo pinned to it queues forever.'
         type: string
         required: false
-        default: 'ferrlabs-k8s-light'
+        default: ''
 
 permissions:
   pull-requests: read
@@ -61,7 +61,7 @@ jobs:
     # n'occupe aucun runner. Vérifié : le SHA porte alors
     # `status=completed conclusion=skipped`.
     if: github.event.action != 'synchronize'
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:


### PR DESCRIPTION
Closes #294

```diff
-        description: 'Runner label. Public repos must pass a GitHub-hosted runner — the ferrlabs-k8s group sets allows_public_repositories=false.'
-        default: 'ferrlabs-k8s-light'
+        description: 'Override the runner label. Empty (default) auto-selects by repo visibility: ...'
+        default: ''

-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
```

The old default was `ferrlabs-k8s-light`, and the `ferrlabs-k8s` group sets `allows_public_repositories=false`. A public caller that did not override it got a job no runner could ever accept, stuck at `status: queued`. Since `Conventional commits` is not a required check, that failed silently and PRs merged with a dead gate. #292 is exactly that, on this repo.

The input's own description warned callers to override it on public repos, which is a default admitting it is wrong for half the org.

This is the same shape `reusable-security-scan.yml` already uses, so it is the established pattern here rather than a new one.

## Verified no-op for every current caller

I surveyed all 19 callers:

- **14 private repos** use the default (FerrLabs-Cloud, FerrFlow-Cloud, FerrLens-Cloud, FerrTrack-Cloud, FerrVault-Cloud, FerrGames-Cloud, FerrGrowth-Cloud, FerrFleet-Cloud, Status, Kit, UI, Docker-Runners, Infra). They resolve to `ferrlabs-k8s-light`, exactly as before.
- **5 public repos** pass `ubuntu-latest` explicitly (FerrFlow, FerrVault, MCP, Fixtures, Benchmarks, Changelog). An explicit value still wins, so they are untouched.

No existing job moves. This only removes the trap for the next public caller.

`github.event.repository` is populated under `pull_request_target` and refers to the base repository, so the check is evaluated against the caller's own visibility.