### PR TITLE
chore(ci): move the five no-build helper jobs to the light runner tier

### DIFF
--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -92,7 +92,7 @@ permissions:
 jobs:
   detect:
     name: Detect Go module
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -448,7 +448,7 @@ jobs:
   typos:
     name: Typos
     if: inputs.enable-typos
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: crate-ci/typos@1a51d4b5a03bb97576af186c813af67e9137ba7c # master

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -142,7 +142,7 @@ jobs:
     # hadolint via its static binary (not the hadolint-action Docker container)
     # so it runs on the self-hosted pool for private repos — the ARC runners
     # have buildah but no Docker daemon. Public repos fall back to ubuntu-latest.
-    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -408,7 +408,7 @@ jobs:
     # self-hosted pool for private repos. Public repos fall back to ubuntu-latest.
     # Keyless signing uses the Actions OIDC token, which is available on
     # self-hosted runners too (needs id-token: write, already granted).
-    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.helper-runner != '' && inputs.helper-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:
       - name: Install cosign
         run: |

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -115,7 +115,7 @@ jobs:
     name: Trigger Renovate scan on consumers
     needs: release
     if: ${{ inputs.trigger-renovate && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:
       - name: Dispatch Renovate workflow
         env:


### PR DESCRIPTION
Moves the reusable-workflow jobs that neither build nor install anything from the `ferrlabs-k8s` (medium) default to `ferrlabs-k8s-light`.

| Job | What it actually runs |
|---|---|
| `reusable-ci-go.yml` / `detect` | checkout, then `[ -f go.mod ]` |
| `reusable-ferrflow-release.yml` / `trigger-renovate` | one `gh workflow run`, no checkout at all |
| `reusable-docker-build.yml` / `hadolint` | checkout, curl a 2.4 MB static binary, lint one Dockerfile |
| `reusable-docker-build.yml` / `cosign` | curl a static binary, sign and attest — network-bound |
| `reusable-ci-rust.yml` / `typos` | checkout, run the `typos` scanner |

All five fit the light profile comfortably (500m CPU, 1 Gi RAM, 5 Gi ephemeral): none compiles, none runs `pnpm install`, none pulls a vulnerability database.

Nothing heavier moves. `trivy` and `sbom` stay on medium despite sharing the `helper-runner` fallback expression with `hadolint` and `cosign` — trivy's database alone would not fit the light profile. `opengrep`, `trufflehog` and `snyk` stay where they are: the existing split in `reusable-security-scan.yml`, with `gitleaks`, `osv-scanner` and `zizmor` already defaulting to light, reads as a considered choice rather than an oversight.

The `runner` / `helper-runner` inputs still override, so any caller that needs one of these on a bigger tier keeps that escape hatch.

## What this will and will not do

It will not drain the CI queue, and it would be misleading to present it that way.

The node sits at **93-94% CPU** (11 261-11 349m of 12 000m, sampled three times 8s apart), with the three runner pods themselves as the top consumers at 1857m, 1476m and 1246m. The queue is a symptom of that saturation, not of jobs sitting on the wrong tier, and the three idle `light` slots are not spare capacity — filling them adds concurrent pods to a CPU that is already full.

On top of that, four of the five jobs rarely run: `typos` is disabled on most repos (`skipping` on every PR I checked today), `detect` only applies to Go repos, and `hadolint`/`cosign` only fire on image builds rather than on every PR.

What it does buy is correctness of intent: these jobs stop reserving a 2-CPU/6 Gi slot they never use, so when they do run they are not competing with a build for the same medium slot.

The real lever remains the CPU ceiling, which the MS-A2 node addresses.

## Propagation

Consumer repos pin this repo by SHA (`# main`), so nothing changes until Renovate bumps each pin. Expect this to land gradually rather than at merge.