### PR TITLE
fix(security-scan): fetch the opengrep ruleset over HTTPS instead of git clone

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -214,14 +214,19 @@ jobs:
         env:
           SAST_CONFIG: ${{ inputs.sast-config }}
         run: |
+          set -euo pipefail
           if [ -n "$SAST_CONFIG" ]; then
             echo "path=$SAST_CONFIG" >> "$GITHUB_OUTPUT"
-          else
-            # OpenGrep bundles no rules; the Semgrep registry `auto` shorthand is
-            # not reliably available on the fork, so we ship the community set.
-            git clone --depth 1 https://github.com/opengrep/opengrep-rules.git "$RUNNER_TEMP/opengrep-rules"
-            echo "path=$RUNNER_TEMP/opengrep-rules" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # OpenGrep bundles no rules; the Semgrep registry `auto` shorthand is
+          # not reliably available on the fork, so we ship the community set.
+          DEST="$RUNNER_TEMP/opengrep-rules"
+          mkdir -p "$DEST"
+          TARBALL="$RUNNER_TEMP/opengrep-rules.tar.gz"
+          curl -fsSL -o "$TARBALL" https://codeload.github.com/opengrep/opengrep-rules/tar.gz/refs/heads/main
+          tar -xzf "$TARBALL" -C "$DEST" --strip-components=1
+          echo "path=$DEST" >> "$GITHUB_OUTPUT"
       - name: Fetch the FerrLabs ruleset
         id: ferrlabs-rules
         if: ${{ inputs.ferrlabs-rules }}


### PR DESCRIPTION
## Summary

The `opengrep (SAST)` job fetches the community ruleset with `git clone`, and that clone has been
failing on the self-hosted pool since 2026-09-02 morning:

```
git clone --depth 1 https://github.com/opengrep/opengrep-rules.git "$RUNNER_TEMP/opengrep-rules"
Cloning into '/home/runner/_work/_temp/opengrep-rules'...
fatal: could not read Username for 'https://github.com': No such device or address
##[error]Process completed with exit code 128
```

The job dies there, so nothing is scanned. This replaces the clone with a tarball fetch.

The deciding evidence is inside the same job: the `Install OpenGrep` step immediately before it
curls a release asset from `https://github.com/...` anonymously and succeeds, and the
`Fetch the FerrLabs ruleset` step immediately after curls raw.githubusercontent.com and succeeds.
Plain HTTPS to GitHub works on these runners. Only `git clone` is being asked for credentials, on a
public repository that needs none. Nothing changed on our side that morning either: the reusable
workflow last moved 2026-08-31 05:06, the caller's pin 2026-08-31, and the runner image carries no
git configuration at all.

Rather than keep chasing why git alone wants credentials there, this step now does what the two
working steps around it do.

## Related issue

FerrLabs/Infra#377

## Type of change

- [x] fix — bug fix

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated for the change
- [x] Lint, format, and tests pass locally
- [ ] Docs updated if behavior or usage changed
- [x] No secrets, credentials, or tokens committed

Verified by running the new snippet as the step would:

```
$ curl -fsSL -o "$TARBALL" https://codeload.github.com/opengrep/opengrep-rules/tar.gz/refs/heads/main
$ tar -xzf "$TARBALL" -C "$DEST" --strip-components=1
$ find "$DEST" -name '*.yaml' -o -name '*.yml' | wc -l
2031
```

Same layout `git clone` produced, so `opengrep scan -f "$DEST"` is unchanged. `set -euo pipefail` is
added to the step, which previously had none, so a failed fetch stops the step instead of handing
opengrep an empty directory.

There is no test harness for the reusable workflows in this repo, so the checklist's test box is
left unticked rather than padded.
