### PR TITLE
fix(docker): bound cached OS updates to a day instead of a week

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -62,10 +62,10 @@ on:
         required: false
         default: true
       cache-ttl:
-        description: 'Ignore cached layers older than this (buildah --cache-ttl, e.g. 168h). Bounds how long a stale base image can be reused before a rebuild picks up upstream security updates.'
+        description: 'Ignore cached layers older than this (buildah --cache-ttl, e.g. 24h). Bounds how long an image can keep shipping OS packages that upstream has already patched: a `RUN apk upgrade` layer is only rerun once its cache entry expires, so this is what decides how stale a security update can get. Raise it for an image whose layers are expensive and whose base carries no OS surface.'
         type: string
         required: false
-        default: '168h'
+        default: '24h'
       push-retries:
         description: 'How many times to retry each manifest push if the registry returns a transient error (5xx, network reset). Backoff is 10s, 30s, 90s, … capped at 5 min. Set to 1 to disable retries.'
         type: number


### PR DESCRIPTION
Closes #304

FerrLabs/FerrFlow-Cloud shipped its site image to production carrying `libexpat-2.8.3-r0`, unsigned, because Trivy failed on the two HIGH CVEs that version has and cosign runs after Trivy. Investigated for FerrLabs/FerrFlow-Cloud#896.

The evidence, gathered before changing anything:

```
base nginx-unprivileged:alpine        2 HIGH, both fixed upstream in libexpat 2.8.4-r0
base + the Dockerfile apk upgrade     libexpat-2.8.4-r0, 0 vulnerabilities
the image actually published          libexpat-2.8.3-r0
```

Same Dockerfile, different result, so the build reused a cached `RUN apk upgrade --no-cache` layer. That instruction is the one whose output depends on when it runs, and layer caching assumes the opposite. `cache-ttl` is what bounds it, and its description already said so, but a week is not a bound worth having for a security update: the build succeeds, only the scan complains, and the scan is not readable because code scanning is off on a private repo.

`24h` fixes every consumer at once. No repo overrides the input today, and 17 Dockerfiles across 9 repos run an OS upgrade, so a per-Dockerfile cache-busting `ARG` would be 17 changes plus a guarantee that any new Dockerfile silently misses.

What this costs is expensive layers rebuilding daily rather than weekly. For the Rust images most of that is absorbed by sccache, which caches compilation independently of the layer cache, and the input is still there for an image that wants a longer window on purpose.

What it does not fix, and I am not folding in here: the Trivy findings remain invisible, since `Upload SARIF` degrades to a no-op without Advanced Security. A build that fails on a list nobody can open is the other half of FerrLabs/FerrFlow-Cloud#896 and wants its own change.