### PR TITLE
fix(docker): put the Trivy findings on the run page

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -366,6 +366,46 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The scan below emits SARIF, which is a file, and the Security tab that
+      # would render it needs Advanced Security. A private repo without that
+      # licence gets a no-op upload, so a failed scan blocked the build on a
+      # list nobody could open. This run prints the same findings as a table
+      # and puts them on the run page, next to the failure.
+      #
+      # Separate from the gate on purpose: it must produce its report even when
+      # the gate is about to exit 1, so it runs first and never fails the job.
+      # The Trivy DB is cached within the job, so this is a few seconds.
+      - name: Trivy (report)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        continue-on-error: true
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          image-ref: ${{ inputs.image-name }}:${{ inputs.tag }}
+          format: table
+          output: trivy-report.txt
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+          exit-code: '0'
+      - name: Publish the CVE list
+        if: always()
+        env:
+          IMAGE: ${{ inputs.image-name }}:${{ inputs.tag }}
+          SEVERITY: ${{ inputs.trivy-severity }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Trivy: ${SEVERITY} in ${IMAGE}"
+            echo
+            echo '```'
+            if [ -s trivy-report.txt ]; then
+              cat trivy-report.txt
+            else
+              echo "No ${SEVERITY} vulnerabilities with a published fix."
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         # Authenticate the Trivy DB pull from ghcr.io/aquasecurity/trivy-db.
         # trivy-action already caches the DB (keyed by date), but on the first

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -376,6 +376,7 @@ jobs:
       # the gate is about to exit 1, so it runs first and never fails the job.
       # The Trivy DB is cached within the job, so this is a few seconds.
       - name: Trivy (report)
+        id: report
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         continue-on-error: true
         env:
@@ -393,13 +394,21 @@ jobs:
         env:
           IMAGE: ${{ inputs.image-name }}:${{ inputs.tag }}
           SEVERITY: ${{ inputs.trivy-severity }}
+          OUTCOME: ${{ steps.report.outcome }}
         run: |
           set -euo pipefail
+          # An empty report means "nothing found" only when the scan actually
+          # ran. Without the outcome check, a report step that died before
+          # writing the file would render as "no vulnerabilities", which is the
+          # unreadable run page this step exists to prevent, one square over.
           {
             echo "### Trivy: ${SEVERITY} in ${IMAGE}"
             echo
             echo '```'
-            if [ -s trivy-report.txt ]; then
+            if [ "${OUTCOME}" != "success" ]; then
+              echo "The scan did not complete (outcome: ${OUTCOME}). See the Trivy (report) step above."
+              echo "This says nothing about whether the image is clean."
+            elif [ -s trivy-report.txt ]; then
               cat trivy-report.txt
             else
               echo "No ${SEVERITY} vulnerabilities with a published fix."


### PR DESCRIPTION
Closes #306

The second half of FerrLabs/FerrFlow-Cloud#896. The cache fix in #305 stopped the site image shipping patched-away CVEs; this one stops a failing scan being unreadable.

The scan runs with `format: sarif`, which writes a file and prints nothing, and the Security tab that would render it needs Advanced Security. So the run page said `Trivy (CVE scan): failure` and the log ended at the scan summary. Working out that it was two `libexpat` HIGHs with a published fix meant pulling the image and scanning it by hand, and every proposed fix before that was guesswork.

A table run now precedes the gate and its output goes to the job summary, so the CVE list is on the run page next to the failure. It carries `exit-code: 0` and `continue-on-error`, because a reporting step that can fail the job would recreate the problem it exists to solve. The gate is unchanged.

Ordered before the gate rather than after it with `if: always()`, so the report exists by the time the gate can fail, and the summary step is `if: always()` so an infrastructure failure in the report still leaves a heading rather than nothing.

The extra scan is cheap. The trivy-action caches the DB within the job, and the 110 MB download is what dominates the first run, not the scan.

Kept `TRIVY_USERNAME`/`TRIVY_PASSWORD` on the new step. The comment on the existing one records a real incident where anonymous concurrent DB pulls were rate-limited and an image shipped unsigned, and an unauthenticated second pull would reintroduce exactly that.

Verified the shell rather than only reading it: extracted the `run` block and ran it against a populated report and a missing one, then ran this repo's own `bash -n` gate over all 85 run blocks in `.github/workflows`, which is clean.