### PR TITLE
ci(rust): allow Kellnr and the FerrLabs licence ref in the deny.toml snippet

### DIFF
--- a/snippets/deny.toml
+++ b/snippets/deny.toml
@@ -18,8 +18,12 @@ allow = [
   "Unicode-DFS-2016",
   "Unicode-3.0",
   "CC0-1.0",
+  "CDLA-Permissive-2.0",
   "Zlib",
   "MPL-2.0",
+  # Kit crates (`ferrlabs-*`) declare this. Every product API consumes them,
+  # so a snippet without it rejects the whole shared layer on adoption.
+  "LicenseRef-FerrLabs-Proprietary",
 ]
 confidence-threshold = 0.93
 
@@ -39,5 +43,9 @@ deny = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-registry = [
+  "https://github.com/rust-lang/crates.io-index",
+  # Kellnr, the private registry serving the `ferrlabs-*` crates.
+  "sparse+https://crates.ferrlabs.com/api/v1/crates/",
+]
 allow-git = []


### PR DESCRIPTION
Part of #308.

The snippet as written rejects the shared layer it is meant to protect. `unknown-registry = "deny"` with only crates.io in `allow-registry` fails on every `ferrlabs-*` crate, and the licence allowlist has no entry for the `LicenseRef-FerrLabs-Proprietary` those crates declare. Any repo copying it in today gets a red build that looks like a supply-chain problem and is not one.

Found while enabling the gate on FerrVault-Cloud (FerrLabs/FerrVault-Cloud#852), where all three of these had to be added by hand before `cargo deny check` would pass.

`CDLA-Permissive-2.0` is `webpki-roots`, which shows up in anything doing TLS. The FerrFlow CLI's own `deny.toml` already allows it, so this also closes a gap between the snippet and the one real consumer we have.

No behaviour change for existing repos: nothing consumes the snippet automatically, it is copied on adoption.