### PR TITLE
ci(rust): give cargo deny its own flags input instead of reusing cargo-flags

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -27,6 +27,10 @@ on:
         description: 'Flags appended to cargo invocations (clippy, test, build)'
         type: string
         default: '--all-features'
+      deny-flags:
+        description: 'Flags passed to cargo deny. Separate from cargo-flags because cargo-deny has its own CLI and rejects things like --all-targets. Feature selection normally belongs in deny.toml [graph] instead.'
+        type: string
+        default: ''
       coverage-flags:
         description: 'Flags for the coverage run (llvm-cov). Defaults to cargo-flags. Set separately when cargo-flags already carries --workspace, to avoid passing it twice to llvm-cov which rejects duplicates.'
         type: string
@@ -429,8 +433,8 @@ jobs:
       - name: cargo deny
         if: inputs.enable-deny
         env:
-          CARGO_FLAGS: ${{ inputs.cargo-flags }}
-        run: cargo deny $CARGO_FLAGS check
+          DENY_FLAGS: ${{ inputs.deny-flags }}
+        run: cargo deny $DENY_FLAGS check
       - name: cargo machete (unused deps)
         if: inputs.enable-machete
         run: |


### PR DESCRIPTION
Part of #308.

The deny step passes `cargo-flags` straight to `cargo deny`:

```yaml
env:
  CARGO_FLAGS: ${{ inputs.cargo-flags }}
run: cargo deny $CARGO_FLAGS check
```

That input documents itself as *'Flags appended to cargo invocations (clippy, test, build)'*, and `cargo-deny` is not cargo: it has its own CLI and rejects most cargo flags. Any caller setting `cargo-flags: --all-targets` gets:

```
error: unexpected argument '--all-targets' found
Usage: cargo-deny --all-features <COMMAND>
##[error]Process completed with exit code 2
```

This is not hypothetical. Enabling `enable-deny` across the org made it fail immediately in FerrFlow-Cloud, FerrTrack-Cloud, FerrLens-Cloud and FerrGrowth-Cloud, which all pass `--all-targets`. The repos that were fine (FerrVault-Cloud, FerrFleet, FerrLabs-Cloud) pass an empty string, and Kit only survives because `--workspace` and `--all-features` happen to be flags cargo-deny does accept.

So the gate looked like it worked for exactly the callers whose flags happened to be compatible.

New optional `deny-flags` input, defaulting to empty. Nothing changes for callers that do not set it, beyond the deny step stopping at the first flag cargo-deny does not understand. Feature selection for cargo-deny normally belongs in `deny.toml`'s `[graph]` section anyway, which is where the deny.toml files added across the org this week already put it.

Callers pinning by SHA need to bump their pin to pick this up.