### PR TITLE
ci(rust): cache the advisory database and retry its fetch

### DIFF
--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -422,7 +422,7 @@ jobs:
         run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: Cache the RustSec advisory database
         if: inputs.enable-deny
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cargo/advisory-dbs
           key: advisory-db-${{ steps.advisory-db-key.outputs.day }}
@@ -446,10 +446,15 @@ jobs:
           if [ "$EXIT" != "0" ]; then
             echo "::warning::cargo audit found advisories (non-blocking — set fail-on-audit: true or update audit-ignore to act on them)"
           fi
-      # Fetching is split out from the check so the network step can be retried
-      # on its own, and so the check itself runs `--offline` and cannot reach
-      # for the database again halfway through. `cargo deny check` re-fetches
-      # even when the cache is warm, which is the call that gets rate limited.
+      # Fetching is split out so the one network-bound step can be retried on
+      # its own, rather than retrying a check that may be failing for a real
+      # reason. Combined with the cache above this turns the rate-limited call
+      # from a fresh clone into an incremental fetch.
+      #
+      # Not `--offline` on the check: that flag applies to the whole crate
+      # graph, not just the advisory database, so on a runner with a cold
+      # registry `cargo metadata` fails with "no matching package named
+      # `anyhow` found". It passes locally only because the registry is warm.
       - name: cargo deny
         if: inputs.enable-deny
         env:
@@ -466,7 +471,7 @@ jobs:
             echo "advisory database fetch failed (attempt $attempt), retrying"
             sleep $((attempt * 15))
           done
-          cargo deny --offline $DENY_FLAGS check
+          cargo deny $DENY_FLAGS check
       - name: cargo machete (unused deps)
         if: inputs.enable-machete
         run: |

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -411,6 +411,22 @@ jobs:
       - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2
         with:
           tool: cargo-audit,cargo-deny,cargo-machete
+      # cargo-deny clones the RustSec database unauthenticated, and GitHub rate
+      # limits that. Our ARC runners share an egress IP, so every Rust job in
+      # the org draws on the same anonymous quota from one address. Keyed on the
+      # day: the database moves often enough that a stale one is worth less than
+      # a daily refresh, and often enough that a week-old cache would be wrong.
+      - name: Advisory database cache key
+        if: inputs.enable-deny
+        id: advisory-db-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+      - name: Cache the RustSec advisory database
+        if: inputs.enable-deny
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/advisory-dbs
+          key: advisory-db-${{ steps.advisory-db-key.outputs.day }}
+          restore-keys: advisory-db-
       - name: cargo audit (RustSec advisories)
         if: inputs.enable-audit
         run: |
@@ -430,11 +446,27 @@ jobs:
           if [ "$EXIT" != "0" ]; then
             echo "::warning::cargo audit found advisories (non-blocking — set fail-on-audit: true or update audit-ignore to act on them)"
           fi
+      # Fetching is split out from the check so the network step can be retried
+      # on its own, and so the check itself runs `--offline` and cannot reach
+      # for the database again halfway through. `cargo deny check` re-fetches
+      # even when the cache is warm, which is the call that gets rate limited.
       - name: cargo deny
         if: inputs.enable-deny
         env:
           DENY_FLAGS: ${{ inputs.deny-flags }}
-        run: cargo deny $DENY_FLAGS check
+        run: |
+          for attempt in 1 2 3; do
+            if cargo deny fetch db; then
+              break
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "::error::could not fetch the RustSec advisory database after 3 attempts"
+              exit 1
+            fi
+            echo "advisory database fetch failed (attempt $attempt), retrying"
+            sleep $((attempt * 15))
+          done
+          cargo deny --offline $DENY_FLAGS check
       - name: cargo machete (unused deps)
         if: inputs.enable-machete
         run: |


### PR DESCRIPTION
Closes #311.

`cargo deny` clones the RustSec database unauthenticated on every run, and GitHub rate limits that:

```
fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads
to protect the stability of the platform. Please retry later or authenticate.
```

It took out FerrLabs/FerrLabs-Cloud#872 and FerrLabs/FerrFleet-Cloud#731 minutes apart. The ARC runners share an egress IP, so with the gate now on in eight repos they all draw on the same anonymous quota from one address.

Three parts:

- **Cache `~/.cargo/advisory-dbs`**, keyed by day. This is what matters: it turns the rate-limited call from a fresh clone into an incremental fetch.
- **Retry `cargo deny fetch db`** three times with backoff, split out from the check so the one network-bound step is retried on its own rather than re-running a check that may be failing for a real reason.
- **`actions/cache` v6**, because v4 runs on Node 20 and the runners now warn about it.

### Two approaches I tried and rejected, with the evidence

**`db-path` pointing at cargo-audit's copy.** This was my own suggestion in #311 and it does not work. `db-path` names the *parent* directory; cargo-deny always creates `advisory-db-<url hash>` inside it, so pointing it at `~/.cargo/advisory-db` yields `~/.cargo/advisory-db/advisory-db-<hash>`, not the checkout cargo-audit made. The two tools cannot share by that route.

**`cargo deny --offline check`.** Looked ideal locally: no fetch, and `advisories ok`. On a runner it fails:

```
[ERROR] failed to fetch crates: error: no matching package named `anyhow` found
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
```

`--offline` applies to the whole crate graph, not just the advisory database, so `cargo metadata` cannot resolve against a cold registry. It passed locally only because my registry was warm, which is exactly the kind of local verification that proves nothing. The reason is now a comment in the workflow so it does not get reintroduced.

### Honest scope

This reduces the exposure rather than removing it: an incremental fetch is still an unauthenticated GitHub request. The complete fix is authenticating the clone, which I did not do because it puts a credential in git config for a third-party clone and zizmor will have opinions. If the limit still bites with the cache in place, that is the next step.

Verification on a runner is in progress; I will not merge this on local results alone after `--offline` passed locally and failed in CI.