### PR TITLE
fix(renovate): trust the @ferrflow npm scope

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,6 +62,25 @@
       "groupName": "FerrLabs npm packages"
     },
     {
+      "description": "FerrFlow npm packages — same trust as the @ferrlabs rule above, minus the registry override. The npm publishes were consolidated under @ferrflow (the `ferrflow` wrapper, `@ferrflow/*`, `@ferrflow/wasm`) and those live on npmjs.org, not GHCR, so pointing them at npm.pkg.github.com would break the lookup. Without this rule the scope falls through to the third-party rule below and its three-day quarantine, which held FerrFlow-Cloud's `@ferrflow/doc` pin four versions behind and kept merged documentation off ferrflow.com.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "/^@ferrflow\\//",
+        "ferrflow"
+      ],
+      "schedule": [
+        "* * * * *"
+      ],
+      "minimumReleaseAge": "0",
+      "internalChecksFilter": "none",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "FerrFlow npm packages"
+    },
+    {
       "description": "FerrLabs Kit crates pinned via git rev — scan often, merge without delay. Targets the depName the customManager below stamps (`FerrLabs/Kit`); `matchPackageNames` would compare against the packageName field (the full URL), so use matchDepNames here. internalChecksFilter:none skips stability-days.",
       "matchManagers": [
         "custom.regex"
@@ -106,7 +125,9 @@
         "npm"
       ],
       "matchPackageNames": [
-        "!/^@ferrlabs\\//"
+        "!/^@ferrlabs\\//",
+        "!/^@ferrflow\\//",
+        "!ferrflow"
       ],
       "matchUpdateTypes": [
         "patch",


### PR DESCRIPTION
Adds a sibling to the `@ferrlabs` npm rule covering `@ferrflow`, and excludes that scope from the third-party rule so the two do not both claim it.

The trusted rule matches `/^@ferrlabs\//`. The npm publishes were consolidated under `@ferrflow` and the `@ferrlabs` alias was dropped without ever being published, so nothing in the current scope matched it. Everything fell through to `matchPackageNames: ["!/^@ferrlabs\//"]`, which is the third-party policy with a three-day quarantine, applied to packages our own CI publishes from a repository in this org.

Deliberately **not** reusing the existing rule. It carries `registryUrls: ["https://npm.pkg.github.com"]` on the grounds that "these packages aren't on npmjs.org", which is true of `@ferrlabs` and false of `@ferrflow`: `npm view @ferrflow/doc version` resolves against the public registry with no auth. Adding the scope to that matcher would have pointed it at GHCR and broken the lookup. The new rule copies the trust policy and omits the override.

`ferrflow` is listed alongside the scope because the npm wrapper package is published under that bare name, not under `@ferrflow/`.

What this was blocking: `FerrFlow-Cloud/site/package.json` pins `"@ferrflow/doc": "7.17.0"`, added on 2026-09-04. npm serves 7.19.1 and no Renovate PR exists. Documentation merged into FerrFlow could not reach ferrflow.com, which is why the `Build metadata` section added in FerrLabs/FerrFlow#1026 and shipped in 7.18.0 is still not on the live site.

Closes #317
