### PR TITLE
chore(ci): drop the French comments from the workflows

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,10 +1,5 @@
 name: PR title
 
-# `pull_request_target` est délibéré et sûr ici : le job ne fait aucun
-# `checkout`, n'exécute donc rien qui vienne de la PR, et ne lit que le titre
-# dans la charge utile de l'événement avec `pull-requests: read`. C'est aussi ce
-# qui empêche une PR de fork d'affaiblir sa propre validation en modifiant ce
-# fichier, ce que `pull_request` autoriserait.
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
@@ -15,15 +10,6 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
-    # sur `synchronize` recalcule la même réponse. Renovate rebase en
-    # permanence, et une seule branche a représenté 24 des 100 derniers runs de
-    # ce workflow sur FerrGrowth-Cloud.
-    #
-    # On saute le job au lieu de retirer `synchronize` du déclencheur, et c'est
-    # délibéré : le workflow continue de produire un check run sur le nouveau
-    # SHA de tête, ce dont un status check requis a besoin, et un job sauté
-    # n'occupe aucun runner.
     if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -78,19 +78,7 @@ jobs:
       #     doesn't hold up the rest),
       #   - grouped shards for tools / libs / infra / games,
       #   - a `rest` catch-all owning every other non-archived repo.
-      # Shards are mutually exclusive: un dépôt tombe dans exactement un.
-      #
-      # ⚠️ `rest` n'a jamais rien attrapé jusqu'au 2026-08-09 : le filtre
-      # s'écrivait `$named | index(.)`, où le `.` dans `index()` désigne
-      # l'entrée du pipe — c'est-à-dire `$named` lui-même, pas le dépôt
-      # courant. `$named | index($named)` vaut 0, donc `| not` valait false
-      # pour TOUT dépôt et `$rest` sortait toujours vide, sans erreur ni
-      # shard visible. Six dépôts n'ont donc jamais été scannés, dont
-      # FerrGames-Discord — qui consomme ce reusable de release.
-      #
-      # La forme `. as $n | $named | index($n)` capture la valeur courante
-      # avant le pipe. Si un shard `rest` apparaît dans un run, c'est normal :
-      # c'est ce qui manquait.
+      # Shards are mutually exclusive.
       - name: Compute shard matrix
         id: plan
         env:

--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -98,18 +98,6 @@ on:
 
 permissions:
   contents: read
-  # Lecture du registre npm de GitHub (`npm.pkg.github.com`), où vivent les
-  # paquets `@ferrlabs/*`.
-  #
-  # Sans cette permission, le repli sur `GITHUB_TOKEN` ne peut pas fonctionner :
-  # il est émis sans droit sur les paquets, et l'installation échoue en 401. Le
-  # CI ne tenait donc que par le PAT `FERRFLOW_PACKAGES_READ`, sans que la
-  # dépendance soit visible — un secret d'organisation absent aurait produit une
-  # erreur d'authentification incompréhensible plutôt qu'un repli.
-  #
-  # C'est aussi le préalable pour se passer de ce PAT classique (Infra#264) :
-  # une fois l'accès Actions du paquet accordé aux dépôts consommateurs,
-  # `GITHUB_TOKEN` suffit.
   packages: read
 
 jobs:
@@ -209,16 +197,6 @@ jobs:
     # build/lint regardless of their result.
     if: inputs.enable-sonar && !cancelled()
     needs: build
-    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
-    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
-    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
-    # l'appel imbrique a reusable-sonarqube-scan, qui demande
-    # `pull-requests: write`, fait echouer le run entier au demarrage --
-    # startup_failure, sans job ni message exploitable. Pose au niveau job et
-    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
-    # restent en lecture seule.
-    # L'appelant doit accorder la meme permission sur le job qui appelle ce
-    # workflow, sinon il n'y a rien a transmettre.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -265,16 +265,6 @@ jobs:
     if: inputs.enable-sonar && !cancelled()
     # needs: test so the coverage artifact exists before the scan downloads it.
     needs: test
-    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
-    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
-    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
-    # l'appel imbrique a reusable-sonarqube-scan, qui demande
-    # `pull-requests: write`, fait echouer le run entier au demarrage --
-    # startup_failure, sans job ni message exploitable. Pose au niveau job et
-    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
-    # restent en lecture seule.
-    # L'appelant doit accorder la meme permission sur le job qui appelle ce
-    # workflow, sinon il n'y a rien a transmettre.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -130,18 +130,6 @@ on:
 
 permissions:
   contents: read
-  # Lecture du registre npm de GitHub (`npm.pkg.github.com`), où vivent les
-  # paquets `@ferrlabs/*`.
-  #
-  # Sans cette permission, le repli sur `GITHUB_TOKEN` ne peut pas fonctionner :
-  # il est émis sans droit sur les paquets, et l'installation échoue en 401. Le
-  # CI ne tenait donc que par le PAT `FERRFLOW_PACKAGES_READ`, sans que la
-  # dépendance soit visible — un secret d'organisation absent aurait produit une
-  # erreur d'authentification incompréhensible plutôt qu'un repli.
-  #
-  # C'est aussi le préalable pour se passer de ce PAT classique (Infra#264) :
-  # une fois l'accès Actions du paquet accordé aux dépôts consommateurs,
-  # `GITHUB_TOKEN` suffit.
   packages: read
 
 jobs:
@@ -282,16 +270,6 @@ jobs:
     if: inputs.enable-sonar && !cancelled()
     # needs: test so the coverage artifact exists before the scan downloads it.
     needs: test
-    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
-    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
-    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
-    # l'appel imbrique a reusable-sonarqube-scan, qui demande
-    # `pull-requests: write`, fait echouer le run entier au demarrage --
-    # startup_failure, sans job ni message exploitable. Pose au niveau job et
-    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
-    # restent en lecture seule.
-    # L'appelant doit accorder la meme permission sur le job qui appelle ce
-    # workflow, sinon il n'y a rien a transmettre.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -257,11 +257,6 @@ jobs:
       PGHOST: ${{ inputs.integration-db-host }}
       PGPORT: ${{ inputs.integration-db-port }}
       PGUSER: ${{ inputs.integration-db-user }}
-    # Ce job parle a postgres-ci.github-runner.svc.cluster.local, un service
-    # INTERNE au cluster de production : il doit rester sur `ferrlabs-k8s` et
-    # ne jamais etre route vers un autre site (le Homelab, par exemple), d'ou
-    # ce service est injoignable -- l'echec serait une resolution DNS, sans
-    # rapport apparent avec la base de donnees.
     runs-on: ${{ inputs.integration-runner != '' && inputs.integration-runner || (github.event.repository.private && 'ferrlabs-k8s' || 'ubuntu-latest') }}
     defaults:
       run:
@@ -619,16 +614,6 @@ jobs:
     # for full reports.
     if: inputs.enable-sonar && !cancelled()
     needs: coverage
-    # Le job qui commente le delta sur une PR a besoin d'ecrire dessus, et un
-    # workflow appele ne peut pas obtenir plus que ce que son appelant lui
-    # accorde : sans cette ligne, ce workflow plafonne a `contents: read` et
-    # l'appel imbrique a reusable-sonarqube-scan, qui demande
-    # `pull-requests: write`, fait echouer le run entier au demarrage --
-    # startup_failure, sans job ni message exploitable. Pose au niveau job et
-    # non du workflow : seul ce job obtient l'ecriture, les jobs de build
-    # restent en lecture seule.
-    # L'appelant doit accorder la meme permission sur le job qui appelle ce
-    # workflow, sinon il n'y a rien a transmettre.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -1,10 +1,9 @@
 name: Reusable — PR title (Conventional Commits)
 
-# Le titre de la PR devient le message de commit sur `main` au squash-merge, et
-# FerrFlow en déduit le bump de version. Un titre mal formé produit donc
-# silencieusement une mauvaise version, ou aucune. D'où la validation.
-#
-# Les appelants déclarent :
+# Callers declare the block below. `pull_request_target` is safe here
+# because this workflow checks nothing out and reads only the title from
+# the event payload, and the caller's `permissions` block is mandatory:
+# a called workflow can only narrow what the caller grants it.
 #
 #   on:
 #     pull_request_target: # zizmor: ignore[dangerous-triggers]
@@ -17,23 +16,6 @@ name: Reusable — PR title (Conventional Commits)
 #     title:
 #       name: PR title
 #       uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@<sha>
-#
-# Le bloc `permissions` de l'appelant n'est pas facultatif : un workflow appelé
-# ne peut que restreindre ce que l'appelant lui donne, jamais l'élargir. Sans
-# lui, le run finit en `startup_failure` avec « is requesting 'pull-requests:
-# read', but is only allowed 'pull-requests: none' », et un startup_failure ne
-# produit AUCUN check run sur le SHA de tête. Sur un dépôt où ce check est
-# requis, c'est un blocage silencieux de toutes les PR.
-#
-# Le check produit s'appelle alors `PR title / Conventional commits` : un job
-# `uses:` compose toujours le nom de l'appelant et celui du job appelé. C'est ce
-# nom-là que les rulesets doivent exiger, pas `Conventional commits` seul.
-#
-# `pull_request_target` est délibéré et sûr : le job ne fait aucun `checkout`,
-# n'exécute donc rien qui vienne de la PR, et ne lit que le titre dans la charge
-# utile de l'événement avec `pull-requests: read`. C'est aussi ce qui empêche une
-# PR de fork d'affaiblir sa propre validation en modifiant le fichier, ce que
-# `pull_request` autoriserait.
 
 on:
   workflow_call:
@@ -50,16 +32,6 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
-    # sur `synchronize` recalcule la même réponse, et Renovate rebase en
-    # permanence. Une seule branche a représenté 24 des 100 derniers runs de ce
-    # workflow sur FerrGrowth-Cloud.
-    #
-    # On saute le job au lieu de retirer `synchronize` du déclencheur, et c'est
-    # délibéré : le workflow continue de produire un check run sur le nouveau
-    # SHA de tête, ce dont un status check requis a besoin, et un job sauté
-    # n'occupe aucun runner. Vérifié : le SHA porte alors
-    # `status=completed conclusion=skipped`.
     if: github.event.action != 'synchronize'
     runs-on: ${{ inputs.runner != '' && inputs.runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     steps:

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -430,10 +430,6 @@ jobs:
     name: Scans ran
     needs: [gitleaks, osv-scanner, opengrep, zizmor, snyk]
     if: always()
-    # Même sélection que les scans légers : une assertion en shell n'a aucune
-    # raison de coûter une minute facturée de runner hébergé sur un dépôt
-    # privé, alors que tous les autres jobs de ce workflow atterrissent déjà
-    # sur le pool auto-hébergé.
     runs-on: ${{ inputs.runner != '' && inputs.runner || inputs.light-runner != '' && inputs.light-runner || (github.event.repository.private && 'ferrlabs-k8s-light' || 'ubuntu-latest') }}
     permissions: {}
     steps:


### PR DESCRIPTION
Removes the French comment blocks from this repository's GitHub Actions workflows: 8 file(s), 152 lines.

Deletion rather than translation, per the decision on the tracking issue. The org rule is that everything is written in English, and the code-comment rule is that comments do not belong in the first place, so the two point the same way here.

Detection was calibrated rather than eyeballed. A block counts as French on one elision (`d'`, `l'`, `qu'`) or two French function words. Accents were deliberately demoted to corroborating evidence only, because several files carry mojibake (UTF-8 decoded as Latin-1) that puts accented characters inside perfectly English comments; scoring on accents alone flagged an entirely English block in UI. Inline trailing comments such as `# zizmor: ignore[...]` are untouched, since only whole-line blocks are considered.

Ref FerrLabs/.github#316
