### PR TITLE
perf(ci): cancel superseded runs across this repository's workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - '.github/workflows/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,6 +9,10 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,10 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # `pull_request_target` runs in the base's context, so `github.ref` is
+  # the base branch and every open PR would share one group. The PR number
+  # keys it per pull request, with `github.ref` left as the fallback.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 permissions:

--- a/.github/workflows/renovate-rebase.yml
+++ b/.github/workflows/renovate-rebase.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dispatch:
     uses: FerrLabs/.github/.github/workflows/reusable-renovate-dispatch.yml@2883414f68b4029d28d8700d2a51d070f7528111 # main

--- a/.github/workflows/renovate-selfcheck.yml
+++ b/.github/workflows/renovate-selfcheck.yml
@@ -37,6 +37,10 @@ on:
     - cron: "30 */6 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 env:

--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -45,7 +45,10 @@ on:
         default: ''
 
 concurrency:
-  group: reusable-pr-title-${{ github.workflow }}-${{ github.ref }}
+  # `pull_request_target` runs in the base's context, so `github.ref` is
+  # the base branch and every open PR would share one group. The PR number
+  # keys it per pull request, with `github.ref` left as the fallback.
+  group: reusable-pr-title-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # Callers trigger on `pull_request_target`, so testing for
   # `pull_request` alone would never cancel anything.
   cancel-in-progress: >-

--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -44,6 +44,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: reusable-pr-title-${{ github.workflow }}-${{ github.ref }}
+  # Callers trigger on `pull_request_target`, so testing for
+  # `pull_request` alone would never cancel anything.
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request_target'
+    || github.event_name == 'pull_request' }}
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -96,6 +96,10 @@ on:
         required: false
         default: true
 
+concurrency:
+  group: reusable-security-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,6 +15,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
Adds `concurrency` to this repository's five own workflows and to the two reusable workflows where it is safe.

`pr-title.yml` and `reusable-pr-title.yml` name `pull_request_target` in their condition rather than `pull_request`, since that is what actually triggers them; testing for the wrong event would have produced a group that never cancels anything.

**Only two of the eleven reusables are included, deliberately.** A group declared in a called workflow is evaluated in the caller's context, and several callers invoke the same reusable repeatedly in one workflow: `reusable-docker-build.yml` 8 times in FerrLabs-Cloud's `docker.yml`, `reusable-ci-node.yml` twice in FerrFleet-Cloud's `ci.yml`, and `reusable-sonarqube-scan.yml` twice in that same run because every `reusable-ci-*` calls it. A caller-scoped group there makes those parallel invocations cancel each other, so FerrLabs-Cloud would build one image and cancel seven. Nothing available inside the called workflow distinguishes one invocation from another, so those need an input from the caller rather than a group the reusable invents. `#321` records the analysis.

`reusable-pr-title.yml` and `reusable-security-scan.yml` are each called at most once per caller workflow and are never nested, so they take a group without that risk.

Release-shaped reusables are excluded for a second reason on top: there is no safe `cancel-in-progress` for a workflow that publishes.

Closes #321
