### PR TITLE
perf(ci): give the remaining reusables a concurrency group

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -96,6 +96,12 @@ on:
       SONAR_TOKEN:
         required: false
 
+concurrency:
+  group: reusable-ci-astro-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/reusable-ci-go.yml
+++ b/.github/workflows/reusable-ci-go.yml
@@ -86,6 +86,12 @@ on:
       SONAR_TOKEN:
         required: false
 
+concurrency:
+  group: reusable-ci-go-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -128,6 +128,12 @@ on:
       FERRFLOW_PACKAGES_READ:
         required: false
 
+concurrency:
+  group: reusable-ci-node-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -157,6 +157,12 @@ on:
       CARGO_REGISTRIES_KELLNR_TOKEN:
         required: false
 
+concurrency:
+  group: reusable-ci-rust-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -129,6 +129,12 @@ on:
         description: 'garage S3 secret key (SCCACHE_S3_SECRET). Pair of sccache-s3-key; both must be set for the cache to be wired in.'
         required: false
 
+concurrency:
+  group: reusable-docker-build-${{ inputs.image-name }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -51,6 +51,12 @@ on:
       FERRLABS_DISPATCH_TOKEN:
         required: false
 
+concurrency:
+  group: reusable-ferrflow-release-${{ github.workflow }}-${{ github.ref }}
+  # Queue rather than cancel. Interrupting a release can leave a tag
+  # pushed with nothing published against it.
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -53,11 +53,13 @@ on:
 
 concurrency:
   group: reusable-ferrflow-release-${{ github.workflow }}-${{ github.ref }}
-  # Collapse rather than queue. Callers invoke this on pushes to main, so
-  # queueing turns three merges in a row into three releases; cancelling
-  # lets the last run cover every commit that landed, in one version.
-  # Never on a tag: that release is already out and its build has to finish.
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  # Queue rather than cancel, as in reusable-release-rust. The release
+  # commit is pushed without `[skip ci]`, so it starts another run of the
+  # caller workflow; workflow-level concurrency is evaluated before the
+  # job-level `chore(release):` guard, so that run would claim the group,
+  # cancel the release still publishing, then skip all of its own jobs.
+  # Collapsing a burst belongs in the caller's own group.
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/reusable-ferrflow-release.yml
+++ b/.github/workflows/reusable-ferrflow-release.yml
@@ -53,9 +53,11 @@ on:
 
 concurrency:
   group: reusable-ferrflow-release-${{ github.workflow }}-${{ github.ref }}
-  # Queue rather than cancel. Interrupting a release can leave a tag
-  # pushed with nothing published against it.
-  cancel-in-progress: false
+  # Collapse rather than queue. Callers invoke this on pushes to main, so
+  # queueing turns three merges in a row into three releases; cancelling
+  # lets the last run cover every commit that landed, in one version.
+  # Never on a tag: that release is already out and its build has to finish.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 permissions:
   contents: write

--- a/.github/workflows/reusable-release-rust.yml
+++ b/.github/workflows/reusable-release-rust.yml
@@ -33,6 +33,12 @@ on:
       FERRFLOW_TOKEN:
         required: false
 
+concurrency:
+  group: reusable-release-rust-${{ inputs.bin-name }}-${{ github.workflow }}-${{ github.ref }}
+  # Queue rather than cancel. Interrupting a release can leave a tag
+  # pushed with nothing published against it.
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -26,6 +26,12 @@ on:
         type: string
         default: 'ferrlabs-k8s'
 
+concurrency:
+  group: reusable-renovate-dispatch-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/reusable-renovate-dispatch.yml
+++ b/.github/workflows/reusable-renovate-dispatch.yml
@@ -28,9 +28,9 @@ on:
 
 concurrency:
   group: reusable-renovate-dispatch-${{ github.workflow }}-${{ github.ref }}
-  # Never cancel on a tag: the release that produced it is already out,
-  # so that build has to complete.
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  # An idempotent dispatch that publishes nothing, so superseding an
+  # in-flight run is safe on any ref, tags included.
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -47,6 +47,12 @@ on:
       SONAR_TOKEN:
         required: true
 
+concurrency:
+  group: reusable-sonarqube-scan-${{ inputs.project-key }}-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  # Never cancel on a tag: the release that produced it is already out,
+  # so that build has to complete.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Reopens the second half of #322, which never reached main. Auto-merge fired on the approval of `7aeb1e0` while two later commits were still being pushed, so the branch merged without them and the merged branch could not carry them afterwards.

What landed in #322: the five own workflows, `reusable-pr-title` and `reusable-security-scan`. What did not: the other nine reusables, and the correction turning the ferrflow release from a queue into a collapse. Verified by content rather than by commit ancestry, since a squash merge leaves the branch commits looking unmerged either way:

```
lint                           concurrency=1
reusable-pr-title              concurrency=1
reusable-docker-build          concurrency=0
reusable-ferrflow-release      concurrency=0
reusable-ci-node               concurrency=0
reusable-sonarqube-scan        concurrency=0
```

The two commits are cherry-picked unchanged onto current main, so all seventeen workflows carry a group again.

Each multi-call reusable keys its group on the input that distinguishes one invocation from another: `image-name` for `reusable-docker-build`, `working-directory` for the four `reusable-ci-*`, `project-key` plus `working-directory` for `reusable-sonarqube-scan`, `bin-name` for `reusable-release-rust`. FerrLabs-Cloud's eight `docker.yml` invocations therefore land in eight distinct groups instead of cancelling each other.

Tags never cancel: `cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}`. A tag build follows a release that already happened.

`reusable-ferrflow-release` collapses rather than queues. Callers invoke it on pushes to main, so queueing turned three merges in a row into three releases; cancelling lets the last run cover every commit that landed, in one version. The residual window is between the tag push and the publish step: a merge arriving there leaves a tag with no release behind it and the next run skips that version number. Recoverable, and it needs a merge inside a window of minutes.

`reusable-release-rust` keeps `cancel-in-progress: false`. It has no caller in the repositories I can inspect, so queueing stays the conservative choice for something that publishes.

Ref #321
