### PR TITLE
fix(ci): let a caller disambiguate the concurrency group per call

### DIFF
--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -7,6 +7,14 @@ on:
         description: 'Package root (for monorepos / nested packages)'
         type: string
         default: '.'
+      concurrency-key:
+        description: >-
+          Disambiguates the concurrency group when one caller job calls this
+          workflow more than once, typically from a matrix. Two calls that
+          share a group cancel each other, and the loser never re-runs: pass
+          the matrix value (or any per-call constant) here.
+        type: string
+        default: ''
       runner:
         description: 'Override the runner label. Empty (default) auto-selects by repo visibility: private repos use the self-hosted ferrlabs-k8s (medium) pool, public repos use ubuntu-latest.'
         type: string
@@ -129,7 +137,7 @@ on:
         required: false
 
 concurrency:
-  group: reusable-ci-node-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  group: reusable-ci-node-${{ inputs.working-directory }}-${{ inputs.concurrency-key }}-${{ github.workflow }}-${{ github.ref }}
   # Never cancel on a tag: the release that produced it is already out,
   # so that build has to complete.
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -43,12 +43,19 @@ on:
         description: 'OpenGrep ruleset for the SAST import (path/URL for `opengrep scan -f`). Empty clones the community opengrep/opengrep-rules set.'
         type: string
         default: ''
+      concurrency-key:
+        description: >-
+          Disambiguates the concurrency group when one caller job calls this
+          workflow more than once, typically from a matrix. Two calls that
+          share a group cancel each other, and the loser never re-runs.
+        type: string
+        default: ''
     secrets:
       SONAR_TOKEN:
         required: true
 
 concurrency:
-  group: reusable-sonarqube-scan-${{ inputs.project-key }}-${{ inputs.working-directory }}-${{ github.workflow }}-${{ github.ref }}
+  group: reusable-sonarqube-scan-${{ inputs.project-key }}-${{ inputs.working-directory }}-${{ inputs.concurrency-key }}-${{ github.workflow }}-${{ github.ref }}
   # Never cancel on a tag: the release that produced it is already out,
   # so that build has to complete.
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Closes #333

`reusable-ci-node.yml` and `reusable-sonarqube-scan.yml` both build their concurrency group out of `working-directory`, `github.workflow` and `github.ref`. None of those vary between two calls made from the same caller job, so a matrix caller puts both legs in one group and `cancel-in-progress` kills the first. The cancelled job never re-runs, and with required checks widened it now blocks the pull request for good.

Both workflows take an optional `concurrency-key`, appended to the group. Default is empty, so a caller that does not pass it keeps the exact group it has today and nothing changes for it.

Callers with more than one call then pass the matrix value:

```yaml
    strategy:
      matrix:
        package: [site, app]
    uses: FerrLabs/.github/.github/workflows/reusable-ci-node.yml@<sha>
    with:
      concurrency-key: ${{ matrix.package }}
```

That side needs the pinned digest bumped, which is a PR per repository. Affected today: FerrVault-Cloud, FerrTrack-Cloud and FerrGrowth-Cloud call from a matrix, FerrFleet-Cloud and FerrLens-Cloud make three calls while passing `working-directory` on only one. Their pending Renovate digest PRs pick the fix up on their next rebase.
