### PR TITLE
chore(ci): let pnpm-version follow packageManager by default

### DIFF
--- a/.github/workflows/reusable-ci-astro.yml
+++ b/.github/workflows/reusable-ci-astro.yml
@@ -15,8 +15,13 @@ on:
         type: string
         default: '24'
       pnpm-version:
+        description: >-
+          pnpm version for `pnpm/action-setup`. Empty, the default, makes the
+          action read `packageManager` from the caller's package.json, which
+          keeps CI on the version the repository actually pins. Set it only for
+          a repository that has no `packageManager` field.
         type: string
-        default: '10'
+        default: ''
       install-args:
         type: string
         default: '--frozen-lockfile'

--- a/.github/workflows/reusable-ci-node.yml
+++ b/.github/workflows/reusable-ci-node.yml
@@ -24,9 +24,13 @@ on:
         type: string
         default: '24'
       pnpm-version:
-        description: 'pnpm version'
+        description: >-
+          pnpm version for `pnpm/action-setup`. Empty, the default, makes the
+          action read `packageManager` from the caller's package.json, which
+          keeps CI on the version the repository actually pins. Set it only for
+          a repository that has no `packageManager` field.
         type: string
-        default: '10'
+        default: ''
       package-manager:
         description: 'Package manager (pnpm, npm, yarn)'
         type: string


### PR DESCRIPTION
`reusable-ci-node.yml` and `reusable-ci-astro.yml` default `pnpm-version` to `'10'`. A caller that omits the input therefore builds on pnpm 10 no matter what its own `packageManager` says, and nothing in the caller hints at it. As repositories move to 12, that default quietly tests something nobody runs locally.

The default becomes empty, which is what `pnpm/action-setup` needs to read `packageManager` from the caller's `package.json`. Every caller that already passes `pnpm-version: ''` (FerrVault-Cloud, FerrTrack-Cloud, FerrGrowth-Cloud, FerrFleet-Cloud, FerrLens-Cloud) keeps the exact behaviour it has, and the pin becomes the single source of truth instead of one of three answers.

Callers that pin a version deliberately are unaffected: Status passes `'12.3.4'` and keeps it.

**Order matters.** MCP is the only caller relying on the old default, and it had no `packageManager` field at all. FerrLabs/MCP#339 pins it to `pnpm@12.3.4` and must land first, otherwise its next run asks the action to resolve a version from a file that does not declare one.
